### PR TITLE
Add AVIF image support

### DIFF
--- a/8.1/base/Dockerfile
+++ b/8.1/base/Dockerfile
@@ -84,7 +84,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Configure the gd library
 RUN docker-php-ext-configure \
-  gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include/
+  gd --with-avif --with-freetype --with-jpeg --with-webp
 # RUN docker-php-ext-configure \
 #   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \

--- a/8.2/base/Dockerfile
+++ b/8.2/base/Dockerfile
@@ -84,7 +84,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Configure the gd library
 RUN docker-php-ext-configure \
-  gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include/
+  gd --with-avif --with-freetype --with-jpeg --with-webp
 # RUN docker-php-ext-configure \
 #   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \

--- a/8.3/base/Dockerfile
+++ b/8.3/base/Dockerfile
@@ -84,7 +84,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Configure the gd library
 RUN docker-php-ext-configure \
-  gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include/
+  gd --with-avif --with-freetype --with-jpeg --with-webp
 # RUN docker-php-ext-configure \
 #   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \


### PR DESCRIPTION
Starting with PHP 8.1, the GD extension can support AVIF images. If the GD extension is built without AVIF image support, Drupal shows a warning on its status page.
https://www.php.net/manual/en/image.installation.php