### PR TITLE
Fix CI by updating bake workflows and simplifying target handling

### DIFF
--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      bake_targets:        ${{ steps.detect.outputs.bake_targets }}
       tag_suffix:          ${{ steps.detect.outputs.tag_suffix }}
       latest_php_version:  ${{ steps.detect.outputs.latest_php_version }}
       versions:            ${{ steps.detect.outputs.versions }}
@@ -23,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Determine tag suffix, latest PHP version, and bake targets
+      - name: Determine tag suffix, latest PHP version, and versions
         id: detect
         run: |
           set -euo pipefail
@@ -46,10 +45,6 @@ jobs:
 
           echo "tag_suffix=${TAG_SUFFIX}"                   >> "$GITHUB_OUTPUT"
           echo "latest_php_version=${LATEST_PHP_VERSION}"   >> "$GITHUB_OUTPUT"
-          # Use the matrix parent target names so bake expands them automatically
-          # for all versions in VERSIONS.  Individual expanded names (php7_4-base
-          # etc.) are not resolvable as CLI arguments in docker buildx bake v0.31+.
-          echo "bake_targets=php-base php-secure php-advance" >> "$GITHUB_OUTPUT"
           VERSIONS_LIST=$(find . -maxdepth 1 -mindepth 1 -type d -name '[0-9]*' \
                             | sed 's|./||' | sort -V | tr '\n' ' ' | xargs)
           echo "versions=${VERSIONS_LIST}" >> "$GITHUB_OUTPUT"
@@ -96,7 +91,6 @@ jobs:
           CACHE_FROM_ENABLED:  "false"
         with:
           files:        docker-bake.hcl
-          targets:      ${{ needs.detect-versions.outputs.bake_targets }}
           source:       .
           push:         true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      bake_targets:        ${{ steps.detect.outputs.bake_targets }}
       tag_suffix:          ${{ steps.detect.outputs.tag_suffix }}
       latest_php_version:  ${{ steps.detect.outputs.latest_php_version }}
       versions:            ${{ steps.detect.outputs.versions }}
@@ -28,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect changes and build Bake target list
+      - name: Detect changes
         id: detect
         run: |
           set -euo pipefail
@@ -87,24 +86,11 @@ jobs:
           done < <(find . -maxdepth 1 -mindepth 1 -type d -name '[0-9]*' \
                      | sed 's|./||' | sort -V)
 
-          # Use php-advance as the single target.
-          # Individual expanded names (php7_4-base etc.) are not resolvable as
-          # CLI arguments in docker buildx bake v0.31+; the matrix parent name
-          # php-advance works correctly and, via bake's dependency chain
-          # (php-advance → php-secure → php-secure-int → php-base → php-php-ext),
-          # automatically builds and pushes every tagged image in the chain.
-          # Docker's build cache handles the efficiency: only layers that actually
-          # changed are rebuilt; unchanged versions get cache hits.
           UNIQUE_VERSIONS=$(printf '%s\n' "${CHANGED_VERSIONS[@]+"${CHANGED_VERSIONS[@]}"}" \
                             | awk '!seen[$0]++' | tr '\n' ' ' | xargs)
 
           echo "tag_suffix=${TAG_SUFFIX}"                   >> "$GITHUB_OUTPUT"
           echo "latest_php_version=${LATEST_PHP_VERSION}"   >> "$GITHUB_OUTPUT"
-          if [[ ${#CHANGED_VERSIONS[@]} -gt 0 ]]; then
-            echo "bake_targets=php-advance"                 >> "$GITHUB_OUTPUT"
-          else
-            echo "bake_targets="                            >> "$GITHUB_OUTPUT"
-          fi
           echo "versions=${UNIQUE_VERSIONS}"                >> "$GITHUB_OUTPUT"
 
           # Determine build platforms from the official PHP base image manifest,
@@ -120,7 +106,7 @@ jobs:
 
   build:
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.bake_targets != '' }}
+    if: ${{ needs.detect-changes.outputs.versions != '' }}
     runs-on: ubuntu-latest
     permissions: {}
 
@@ -149,7 +135,6 @@ jobs:
           PLATFORMS:          ${{ needs.detect-changes.outputs.platforms }}
         with:
           files:        docker-bake.hcl
-          targets:      ${{ needs.detect-changes.outputs.bake_targets }}
           source:       .
           push:         true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -23,6 +23,14 @@
 #   downloader, phpX_Y-php-ext, phpX_Y-secure-int
 # All of these are still cached in GitHub Actions (type=gha, mode=max).
 
+# ─── Default group ───────────────────────────────────────────────────────────
+# Running `docker buildx bake` without arguments builds this group.
+# php-advance depends on the full chain, so every tagged image is built and
+# pushed automatically; no explicit target list is needed in CI.
+group "default" {
+  targets = ["php-advance"]
+}
+
 variable "REPO"                          { default = "devpanel/php"          }
 variable "TAG_SUFFIX"                    { default = ""                       }
 variable "VERSIONS"                      { default = "7.4 8.0 8.1 8.2 8.3"   }


### PR DESCRIPTION
This pull request simplifies and streamlines the Docker build GitHub Actions workflows by removing the need to explicitly calculate and pass build target lists. Instead, the workflows now use a default group in `docker-bake.hcl` that builds all necessary images automatically. The detection logic in the workflows is also simplified to only track which PHP versions have changed, not the specific targets. This results in less complex and more maintainable CI configuration.

Key changes include:

**Workflow simplification and target calculation removal:**

* Removed calculation and usage of explicit `bake_targets` in both `.github/workflows/docker-build-all.yml` and `.github/workflows/docker-build-on-push.yml`. The workflows now only track changed PHP versions and rely on the default group in `docker-bake.hcl` to build all necessary images. [[1]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L16) [[2]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L26-R25) [[3]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L40-L52) [[4]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L99) [[5]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L19) [[6]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L31-R30) [[7]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L66-R94) [[8]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L122-R109) [[9]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L151)

**Improved version detection logic:**

* Updated the change detection logic in `docker-build-on-push.yml` to only output the list of changed PHP versions, deduplicated and space-separated, instead of calculating a list of build targets.

**docker-bake.hcl enhancement:**

* Added a `default` group to `docker-bake.hcl` that builds all required images by default, removing the need for explicit target lists in CI.

These changes make the CI configuration more robust and easier to maintain by reducing complexity and relying on the build system's dependency resolution.