### PR TITLE
Fix Docker buildx bake GITHUB_TOKEN handling in workflows

### DIFF
--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -93,4 +93,3 @@ jobs:
           files:        docker-bake.hcl
           source:       .
           push:         true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -137,4 +137,3 @@ jobs:
           files:        docker-bake.hcl
           source:       .
           push:         true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -80,7 +80,7 @@ target "downloader" {
     LATEST_PHP_VERSION = LATEST_PHP_VERSION
     CODESERVER_VERSION = CODESERVER_VERSION
   }
-  secret     = ["id=github_token"]
+  secret     = ["id=github_token,env=GITHUB_TOKEN"]
   cache-from = cache_from("downloader")
   cache-to   = cache_to("downloader")
   # No tags → not pushed to Docker Hub
@@ -103,7 +103,6 @@ target "_php-ext-common" {
     common            = "./base"
   }
   platforms  = split(",", PLATFORMS)
-  secret     = ["id=github_token"]
   # No tags → not pushed to Docker Hub
 }
 
@@ -127,7 +126,6 @@ target "php-php-ext" {
 
 target "_base-common" {
   platforms  = split(",", PLATFORMS)
-  secret     = ["id=github_token"]
 }
 
 target "php-base" {


### PR DESCRIPTION
This pull request updates how the GitHub token is handled in Docker build workflows and the `docker-bake.hcl` configuration. The main goal is to improve the way secrets are passed to Docker builds, ensuring the `GITHUB_TOKEN` environment variable is used directly, and to clean up unnecessary secret references in build targets that don't require them.

**Workflow and secrets management updates:**

* In both `.github/workflows/docker-build-all.yml` and `.github/workflows/docker-build-on-push.yml`, the `github-token` parameter is removed from the Docker build step, so the workflow no longer explicitly passes the GitHub token as an argument. [[1]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L96) [[2]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L140)
* In the `downloader` target of `docker-bake.hcl`, the secret is now specified as `id=github_token,env=GITHUB_TOKEN`, making sure the build uses the `GITHUB_TOKEN` environment variable directly.

**Build configuration cleanup:**

* The `secret = ["id=github_token"]` lines have been removed from the `_php-ext-common` and `_base-common` targets in `docker-bake.hcl`, since these targets do not require the GitHub token for their build process. [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L106) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L130)