### PR TITLE
Fix `php:-apache` build failure: move `ARG PHP_VERSION` to pre-FROM s…

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -106,7 +106,7 @@ jobs:
 
   build:
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.versions != '' }}
+    if: ${{ needs.detect-changes.outputs.versions != '' && needs.detect-changes.outputs.latest_php_version != '' }}
     runs-on: ubuntu-latest
     permissions: {}
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,7 @@
 # 'common-downloader' named context in docker-bake.hcl.  It is cached in
 # GitHub Actions (type=gha) but never pushed to Docker Hub.
 ARG LATEST_PHP_VERSION=8.3
+ARG PHP_VERSION=8.3
 FROM php:${LATEST_PHP_VERSION}-apache AS downloader
 
 ARG CODESERVER_MAJOR_VERSION=4
@@ -87,7 +88,6 @@ exit(1); \
 #
 # This stage is referenced as the 'common-php-ext' Bake named context.
 # It is cached in GitHub Actions (type=gha) but never pushed to Docker Hub.
-ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-apache AS php-ext-common
 
 #== System Environments


### PR DESCRIPTION
…cope (#125)

* Fix ARG PHP_VERSION scope in base/Dockerfile and add workflow validation



* Move latest_php_version check to job-level if condition



---------