### PR TITLE
Suppress APT output, make github_token optional, and add retry logic

### DIFF
--- a/7.4/base/Dockerfile
+++ b/7.4/base/Dockerfile
@@ -15,10 +15,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # PHP 7.4 (Debian 10) specific packages: libpcre3/libpcre3-dev (no libavif-dev)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      libpcre3 \
-      libpcre3-dev \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends \
+          libpcre3 \
+          libpcre3-dev \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure gd (PHP 7.4: no avif support)

--- a/8.0/base/Dockerfile
+++ b/8.0/base/Dockerfile
@@ -13,9 +13,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # PHP 8.0 (Debian 11) specific package: libpcre2-dev (no libavif-dev)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      libpcre2-dev \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends \
+          libpcre2-dev \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure gd (PHP 8.0: no avif support)

--- a/8.1/base/Dockerfile
+++ b/8.1/base/Dockerfile
@@ -12,10 +12,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # PHP 8.1+ specific packages: libavif-dev (avif gd support) and libpcre2-dev
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      libavif-dev \
-      libpcre2-dev \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends \
+          libavif-dev \
+          libpcre2-dev \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure gd with avif support (PHP 8.1+)

--- a/8.2/base/Dockerfile
+++ b/8.2/base/Dockerfile
@@ -12,10 +12,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # PHP 8.2 specific packages: libavif-dev (avif gd support) and libpcre2-dev
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      libavif-dev \
-      libpcre2-dev \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends \
+          libavif-dev \
+          libpcre2-dev \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure gd with avif support (PHP 8.1+)

--- a/8.3/base/Dockerfile
+++ b/8.3/base/Dockerfile
@@ -14,10 +14,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # PHP 8.3 specific packages: libavif-dev (avif gd support) and libpcre2-dev
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      libavif-dev \
-      libpcre2-dev \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends \
+          libavif-dev \
+          libpcre2-dev \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure gd with avif support (PHP 8.1+)

--- a/advance/Dockerfile
+++ b/advance/Dockerfile
@@ -8,14 +8,26 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 USER root
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends lsb-release curl gpg \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends lsb-release curl gpg \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends redis supervisor \
-	&& rm -rf /var/lib/apt/lists/*
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update \
+        && apt-get install -y --no-install-recommends redis supervisor \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/redis-start.sh /scripts/redis-start.sh
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -123,37 +123,43 @@ ENV CODES_ENABLE=yes
 # Install packages common to all PHP versions.
 # NOTE: libavif-dev (8.1+), libpcre2-dev (8.0+), and libpcre3/libpcre3-dev (7.4)
 # are version-specific and therefore NOT included here.
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-      apt-utils \
-      sendmail-bin \
-      sendmail \
-      sudo \
-      libbz2-dev \
-      libjpeg62-turbo-dev \
-      libpng-dev \
-      libwebp-dev \
-      libfreetype6-dev \
-      libgeoip-dev \
-      wget \
-      libgmp-dev \
-      libmagickwand-dev \
-      libmagickcore-dev \
-      libicu-dev \
-      libldap2-dev \
-      libpspell-dev \
-      libtidy-dev \
-      libxslt1-dev \
-      libyaml-dev \
-      libzip-dev \
-      libmemcached-dev \
-      libssl-dev \
-      zlib1g-dev \
-      zip unzip \
-      git \
-      rsync \
-      ssh \
-      default-mysql-client \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update && apt-get upgrade -y \
+        && apt-get install -y --no-install-recommends \
+          apt-utils \
+          sendmail-bin \
+          sendmail \
+          sudo \
+          libbz2-dev \
+          libjpeg62-turbo-dev \
+          libpng-dev \
+          libwebp-dev \
+          libfreetype6-dev \
+          libgeoip-dev \
+          wget \
+          libgmp-dev \
+          libmagickwand-dev \
+          libmagickcore-dev \
+          libicu-dev \
+          libldap2-dev \
+          libpspell-dev \
+          libtidy-dev \
+          libxslt1-dev \
+          libyaml-dev \
+          libzip-dev \
+          libmemcached-dev \
+          libssl-dev \
+          zlib1g-dev \
+          zip unzip \
+          git \
+          rsync \
+          ssh \
+          default-mysql-client \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure opcache (same for all versions)

--- a/secure/Dockerfile
+++ b/secure/Dockerfile
@@ -10,7 +10,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /home/root
 
 ARG CORERULESET_VERSION="3.3.5"
-RUN apt-get update -y && apt-get install -y --no-install-recommends libapache2-mod-security2 wget unzip \
+# Retry up to 3 times to handle transient apt mirror/network failures (e.g. connection
+# resets mid-download). seq generates the sequence so i takes values 1, 2, 3 in turn.
+RUN for i in $(seq 1 3); do \
+      apt-get update -y \
+        && apt-get install -y --no-install-recommends libapache2-mod-security2 wget unzip \
+        && break \
+      || { [ "$i" -lt 3 ] && sleep 5; }; \
+    done \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/share/modsecurity-crs \
     && wget -O /tmp/modsecurity-crs.zip \


### PR DESCRIPTION
This pull request improves the reliability and consistency of Docker image builds by adding retry logic to all `apt-get` commands across multiple Dockerfiles. This change helps handle transient network or mirror failures during package installation, reducing build failures due to temporary issues. Additionally, the `DEBIAN_FRONTEND=noninteractive` environment variable is set to suppress interactive prompts during package installation, and a minor adjustment is made to an existing mount to make a secret optional.

**Reliability improvements for package installation:**

* Added retry logic (up to 3 attempts with a delay) to all `apt-get update` and `apt-get install` commands in `base/Dockerfile`, `7.4/base/Dockerfile`, `8.0/base/Dockerfile`, `8.1/base/Dockerfile`, `8.2/base/Dockerfile`, `8.3/base/Dockerfile`, `advance/Dockerfile`, and `secure/Dockerfile` to handle transient apt mirror or network failures. (`[[1]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L125-R129)`, `[[2]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7R160-R162)`, `[[3]](diffhunk://#diff-84307bfd9f589b9364459052584910a274e851784a32d0051bd8fb8bfe726808R14-R27)`, `[[4]](diffhunk://#diff-0a0a04300f6534c2a95ab6ebabdd9e9c0d7b8eb192a7d4c3fc449601c1b670f5R12-R24)`, `[[5]](diffhunk://#diff-000a1c28b9719b2c6cb075a767729751d2472690923c609c8752ff59b5ac547dR11-R24)`, `[[6]](diffhunk://#diff-e7eddf1e151298bf3240c524d0ecd26292bead4b896a156e32f9c155f3bc1257R11-R24)`, `[[7]](diffhunk://#diff-fbced1156319084ebaa46e4f6adf57856a5bbd0402a888e56f12a29a69dfd2b9R13-R26)`, `[[8]](diffhunk://#diff-140c51ed606c23adcec7366feaee573b73302a0341c8f42cd35a1aaca674a58eR7-R29)`, `[[9]](diffhunk://#diff-5b0ec88f8c58500ccd6faed43e98dd030479ff52ceb5cb78a844d558fed2471bR9-R20)`)

* Set `DEBIAN_FRONTEND=noninteractive` in all Dockerfiles to suppress interactive prompts during package installation, ensuring non-interactive builds. (`[[1]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7R94)`, `[[2]](diffhunk://#diff-84307bfd9f589b9364459052584910a274e851784a32d0051bd8fb8bfe726808R14-R27)`, `[[3]](diffhunk://#diff-0a0a04300f6534c2a95ab6ebabdd9e9c0d7b8eb192a7d4c3fc449601c1b670f5R12-R24)`, `[[4]](diffhunk://#diff-000a1c28b9719b2c6cb075a767729751d2472690923c609c8752ff59b5ac547dR11-R24)`, `[[5]](diffhunk://#diff-e7eddf1e151298bf3240c524d0ecd26292bead4b896a156e32f9c155f3bc1257R11-R24)`, `[[6]](diffhunk://#diff-fbced1156319084ebaa46e4f6adf57856a5bbd0402a888e56f12a29a69dfd2b9R13-R26)`, `[[7]](diffhunk://#diff-140c51ed606c23adcec7366feaee573b73302a0341c8f42cd35a1aaca674a58eR7-R29)`, `[[8]](diffhunk://#diff-5b0ec88f8c58500ccd6faed43e98dd030479ff52ceb5cb78a844d558fed2471bR9-R20)`)

**Other improvements:**

* Made the `github_token` secret mount optional in `base/Dockerfile` to avoid errors if the secret is not provided. (`[base/DockerfileL28-R28](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L28-R28)`)