### PR TITLE
Implement GHCR write permission handling and fallback caching

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -220,6 +220,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check GHCR write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+
+          FIX_INSTRUCTIONS="To restore full GHCR caching: (1) go to Settings → Actions → General → Workflow permissions and choose 'Read and write permissions', or (2) push an initial image to ghcr.io/${REPO_LC} and link it to this repository so GITHUB_TOKEN can write to the existing package."
+          WARN_SUFFIX="Intermediate-layer caches will not be written to GHCR; the build will continue using the GHA cache instead. ${FIX_INSTRUCTIONS}"
+
+          # Use a temp netrc file so credentials are not exposed as command-line arguments.
+          # umask 0177 ensures the file is created with 0600 from the start (no race window).
+          NETRC=$(umask 0177 && mktemp)
+          printf 'machine ghcr.io login %s password %s\n' "${{ github.actor }}" "${GH_TOKEN}" > "${NETRC}"
+          AUTH_JSON=$(curl -sf --netrc-file "${NETRC}" \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_LC}:push" \
+            2>/dev/null || true)
+          rm -f "${NETRC}"
+
+          REG_TOKEN=$(printf '%s' "${AUTH_JSON}" | jq -r '.token // empty' 2>/dev/null || true)
+
+          if [[ -z "${REG_TOKEN}" ]]; then
+            echo "::warning title=GHCR cache write unavailable::GITHUB_TOKEN could not obtain a GHCR push token for ghcr.io/${REPO_LC}. ${WARN_SUFFIX}"
+            exit 0
+          fi
+
+          # Probe write permission: initiate (and immediately abandon) a blob upload.
+          # Use a temp curl config file so the bearer token is not a command-line argument.
+          CFG=$(umask 0177 && mktemp)
+          printf 'header = "Authorization: Bearer %s"\n' "${REG_TOKEN}" > "${CFG}"
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -K "${CFG}" \
+            "https://ghcr.io/v2/${REPO_LC}/blobs/uploads/")
+          rm -f "${CFG}"
+
+          if [[ "${HTTP_STATUS}" == "202" || "${HTTP_STATUS}" == "201" ]]; then
+            echo "GHCR write access confirmed for ghcr.io/${REPO_LC}."
+          else
+            echo "::warning title=GHCR cache write unavailable::GITHUB_TOKEN does not have write access to ghcr.io/${REPO_LC} (HTTP ${HTTP_STATUS}). ${WARN_SUFFIX}"
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -72,18 +72,21 @@ function "cache_to" {
   result = ["type=gha,scope=${scope},mode=max"]
 }
 
-# cache_from_registry / cache_to_registry: permanent registry-based cache in GHCR.
-# Used for intermediate targets (downloader, php-ext, secure-int) so that their
-# build layers survive beyond the GHA cache eviction window.
+# cache_from_registry / cache_to_registry: registry-based cache in GHCR with
+# GHA cache as a fallback.  Used for intermediate targets (downloader, php-ext,
+# secure-int) so their build layers survive beyond the GHA cache eviction window.
+# The registry write uses ignore-error=true so that a GITHUB_TOKEN permission
+# error does not abort the build; the GHA cache entry is always written and
+# ensures the build can continue and future runs can still hit a warm cache.
 
 function "cache_from_registry" {
-  params = [ref]
-  result = CACHE_FROM_ENABLED == "true" ? ["type=registry,ref=${ref}"] : []
+  params = [ref, scope]
+  result = CACHE_FROM_ENABLED == "true" ? ["type=registry,ref=${ref}", "type=gha,scope=${scope}"] : []
 }
 
 function "cache_to_registry" {
-  params = [ref]
-  result = ["type=registry,ref=${ref},mode=max"]
+  params = [ref, scope]
+  result = ["type=registry,ref=${ref},mode=max,ignore-error=true", "type=gha,scope=${scope},mode=max"]
 }
 
 # ─── Shared downloader (pushed to GHCR, NOT pushed to Docker Hub) ────────────
@@ -101,8 +104,8 @@ target "downloader" {
   }
   secret     = ["id=github_token,env=GITHUB_TOKEN"]
   tags       = ["${GHCR_REPO}:downloader${TAG_SUFFIX}"]
-  cache-from = cache_from_registry("${GHCR_REPO}:cache-downloader${TAG_SUFFIX}")
-  cache-to   = cache_to_registry("${GHCR_REPO}:cache-downloader${TAG_SUFFIX}")
+  cache-from = cache_from_registry("${GHCR_REPO}:cache-downloader${TAG_SUFFIX}", "downloader")
+  cache-to   = cache_to_registry("${GHCR_REPO}:cache-downloader${TAG_SUFFIX}", "downloader")
 }
 
 # ─── Common php-ext intermediates (pushed to GHCR, NOT pushed to Docker Hub) ─
@@ -133,8 +136,8 @@ target "php-php-ext" {
   inherits = ["_php-ext-common"]
   args     = { PHP_VERSION = version }
   tags       = ["${GHCR_REPO}:${version}-php-ext${TAG_SUFFIX}"]
-  cache-from = cache_from_registry("${GHCR_REPO}:cache-${version}-php-ext${TAG_SUFFIX}")
-  cache-to   = cache_to_registry("${GHCR_REPO}:cache-${version}-php-ext${TAG_SUFFIX}")
+  cache-from = cache_from_registry("${GHCR_REPO}:cache-${version}-php-ext${TAG_SUFFIX}", "php${ver_key(version)}-php-ext")
+  cache-to   = cache_to_registry("${GHCR_REPO}:cache-${version}-php-ext${TAG_SUFFIX}", "php${ver_key(version)}-php-ext")
 }
 
 # ─── Base final images ────────────────────────────────────────────────────────
@@ -187,8 +190,8 @@ target "php-secure-int" {
   inherits = ["_secure-int-common"]
   contexts = { base-image = "target:php${ver_key(version)}-base" }
   tags       = ["${GHCR_REPO}:${version}-secure-int${TAG_SUFFIX}"]
-  cache-from = cache_from_registry("${GHCR_REPO}:cache-${version}-secure-int${TAG_SUFFIX}")
-  cache-to   = cache_to_registry("${GHCR_REPO}:cache-${version}-secure-int${TAG_SUFFIX}")
+  cache-from = cache_from_registry("${GHCR_REPO}:cache-${version}-secure-int${TAG_SUFFIX}", "php${ver_key(version)}-secure-int")
+  cache-to   = cache_to_registry("${GHCR_REPO}:cache-${version}-secure-int${TAG_SUFFIX}", "php${ver_key(version)}-secure-int")
 }
 
 # ─── Secure final images ──────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request improves the reliability and transparency of Docker image build caching by enhancing how registry-based caches are managed and by adding a permissions check for GitHub Container Registry (GHCR) write access. The updates ensure that builds gracefully fall back to GitHub Actions (GHA) cache if registry write access is unavailable, and provide clear warnings and instructions when this occurs.

**Caching improvements and fallback logic:**

* Updated the `cache_from_registry` and `cache_to_registry` functions in `docker-bake.hcl` to always include the GHA cache as a fallback and to use `ignore-error=true` for registry writes, preventing build failures if GHCR permissions are insufficient.
* Modified all intermediate build targets (`downloader`, `php-php-ext`, `php-secure-int`) to use the new cache functions with explicit cache scopes, ensuring more robust and granular caching. [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L104-R108) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L136-R140) [[3]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L190-R194)

**GHCR permissions check and user guidance:**

* Added a new step in `.github/workflows/build-php-images.yml` to proactively check for GHCR write access using the current `GITHUB_TOKEN`. If access is unavailable, the workflow emits a clear warning and provides actionable instructions to restore full caching functionality.