### PR TITLE
Fix Docker Buildx Bake Matrix Target Resolution

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -321,6 +321,5 @@ jobs:
           GHCR_REPO:           ${{ steps.ghcr.outputs.repo }}
         with:
           files:   docker-bake.hcl
-          source:  .
           push:    true
           targets: ${{ needs.detect.outputs.targets }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for building PHP images. The change removes the `source: .` line from the Docker build step, likely to rely on the default source context or to fix a configuration issue.