### PR TITLE
Fix PHP version targeting for Docker builds to avoid regression

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -45,7 +45,8 @@ jobs:
       tag_suffix:          ${{ steps.detect.outputs.tag_suffix }}
       latest_php_version:  ${{ steps.detect.outputs.latest_php_version }}
       versions:            ${{ steps.detect.outputs.versions }}
-      targets:             ${{ steps.detect.outputs.targets }}
+      versions_base:       ${{ steps.detect.outputs.versions_base }}
+      versions_secure:     ${{ steps.detect.outputs.versions_secure }}
       platforms:           ${{ steps.detect.outputs.platforms }}
 
     steps:
@@ -99,78 +100,70 @@ jobs:
             ADVANCE_COMMON=$(path_changed "advance/")
             BAKE_CHANGED=$(path_changed "docker-bake.hcl")
 
-            CHANGED_VERSIONS=()
-            ALL_VERSIONS_CHANGED=false
-
-            if [[ $BASE_COMMON -gt 0 || $SECURE_COMMON -gt 0 || $ADVANCE_COMMON -gt 0 || $BAKE_CHANGED -gt 0 ]]; then
-              ALL_VERSIONS_CHANGED=true
-            fi
+            # Per-version, per-stage tracking arrays.
+            # VERSIONS_BASE_ARR / VERSIONS_SECURE_ARR: versions that need that
+            # stage pushed to Docker Hub (cascade: base → secure → advance).
+            # VERSIONS_ADV_ARR: union — every version that needs any rebuild.
+            VERSIONS_BASE_ARR=()
+            VERSIONS_SECURE_ARR=()
+            VERSIONS_ADV_ARR=()
 
             while IFS= read -r VER; do
-              if $ALL_VERSIONS_CHANGED; then
-                CHANGED_VERSIONS+=("$VER")
-              else
-                BASE_VER=$(path_changed "${VER}/base/")
-                SECURE_VER=$(path_changed "${VER}/secure/")
-                ADVANCE_VER=$(path_changed "${VER}/advance/")
-                if [[ $BASE_VER -gt 0 || $SECURE_VER -gt 0 || $ADVANCE_VER -gt 0 ]]; then
-                  CHANGED_VERSIONS+=("$VER")
-                fi
+              NEEDS_BASE=false
+              NEEDS_SECURE=false
+              NEEDS_ADVANCE=false
+
+              # Common-dir / bake-file changes affect this version first.
+              if [[ $BAKE_CHANGED -gt 0 || $BASE_COMMON -gt 0 ]]; then
+                NEEDS_BASE=true; NEEDS_SECURE=true; NEEDS_ADVANCE=true
+              elif [[ $SECURE_COMMON -gt 0 ]]; then
+                NEEDS_SECURE=true; NEEDS_ADVANCE=true
+              elif [[ $ADVANCE_COMMON -gt 0 ]]; then
+                NEEDS_ADVANCE=true
               fi
+
+              # Per-version changes (only checked when the common-dir check has
+              # not already set the highest cascade level for this stage).
+              if ! $NEEDS_BASE && [[ $(path_changed "${VER}/base/") -gt 0 ]]; then
+                NEEDS_BASE=true; NEEDS_SECURE=true; NEEDS_ADVANCE=true
+              fi
+              if ! $NEEDS_SECURE && [[ $(path_changed "${VER}/secure/") -gt 0 ]]; then
+                NEEDS_SECURE=true; NEEDS_ADVANCE=true
+              fi
+              if ! $NEEDS_ADVANCE && [[ $(path_changed "${VER}/advance/") -gt 0 ]]; then
+                NEEDS_ADVANCE=true
+              fi
+
+              if $NEEDS_BASE;    then VERSIONS_BASE_ARR+=("$VER");    fi
+              if $NEEDS_SECURE;  then VERSIONS_SECURE_ARR+=("$VER");  fi
+              if $NEEDS_ADVANCE; then VERSIONS_ADV_ARR+=("$VER");     fi
             done < <(find . -maxdepth 1 -mindepth 1 -type d -name '[0-9]*' \
                        | sed 's|./||' | sort -V)
 
-            VERSIONS_OUT=$(printf '%s\n' "${CHANGED_VERSIONS[@]+"${CHANGED_VERSIONS[@]}"}" \
-                          | awk '!seen[$0]++' | tr '\n' ' ' | xargs)
-
-            # Determine which Docker Hub targets to push per version.
-            # Dependency chain: base → (via secure-int) → secure → advance.
-            # When a target changes, every downstream target must also be pushed.
-            # Common-directory changes affect all versions; per-version changes
-            # are evaluated individually so only the affected version's targets
-            # are rebuilt (e.g. a secure change in 8.1 does not rebuild base for 8.1).
-            TARGETS_OUT=""
-            while IFS= read -r VER; do
-              [[ -z "$VER" ]] && continue
-              VER_KEY="${VER//\./_}"
-              VER_NEED_BASE=false
-              VER_NEED_SECURE=false
-              VER_NEED_ADVANCE=false
-              # Common changes that force a rebuild for every version.
-              if [[ $BAKE_CHANGED -gt 0 || $BASE_COMMON -gt 0 ]]; then
-                VER_NEED_BASE=true; VER_NEED_SECURE=true; VER_NEED_ADVANCE=true
-              elif [[ $SECURE_COMMON -gt 0 ]]; then
-                VER_NEED_SECURE=true; VER_NEED_ADVANCE=true
-              elif [[ $ADVANCE_COMMON -gt 0 ]]; then
-                VER_NEED_ADVANCE=true
-              fi
-              # Per-version changes on top of what the common check already requires.
-              if ! $VER_NEED_BASE && [[ $(path_changed "${VER}/base/") -gt 0 ]]; then
-                VER_NEED_BASE=true; VER_NEED_SECURE=true; VER_NEED_ADVANCE=true
-              fi
-              if ! $VER_NEED_SECURE && [[ $(path_changed "${VER}/secure/") -gt 0 ]]; then
-                VER_NEED_SECURE=true; VER_NEED_ADVANCE=true
-              fi
-              if ! $VER_NEED_ADVANCE && [[ $(path_changed "${VER}/advance/") -gt 0 ]]; then
-                VER_NEED_ADVANCE=true
-              fi
-              if $VER_NEED_BASE;    then TARGETS_OUT="${TARGETS_OUT:+$TARGETS_OUT }php${VER_KEY}-base";    fi
-              if $VER_NEED_SECURE;  then TARGETS_OUT="${TARGETS_OUT:+$TARGETS_OUT }php${VER_KEY}-secure";  fi
-              if $VER_NEED_ADVANCE; then TARGETS_OUT="${TARGETS_OUT:+$TARGETS_OUT }php${VER_KEY}-advance"; fi
-            done < <(printf '%s\n' "${CHANGED_VERSIONS[@]+${CHANGED_VERSIONS[@]}}")
+            # VERSIONS = union of all changed versions (= versions needing advance,
+            # since advance cascades from every upstream change).
+            VERSIONS_OUT=$(printf '%s\n' \
+                "${VERSIONS_ADV_ARR[@]+"${VERSIONS_ADV_ARR[@]}"}" \
+              | awk '!seen[$0]++' | tr '\n' ' ' | xargs)
+            VERSIONS_BASE_OUT=$(printf '%s\n' \
+                "${VERSIONS_BASE_ARR[@]+"${VERSIONS_BASE_ARR[@]}"}" \
+              | awk '!seen[$0]++' | tr '\n' ' ' | xargs)
+            VERSIONS_SECURE_OUT=$(printf '%s\n' \
+                "${VERSIONS_SECURE_ARR[@]+"${VERSIONS_SECURE_ARR[@]}"}" \
+              | awk '!seen[$0]++' | tr '\n' ' ' | xargs)
           else
             VERSIONS_OUT=$(find . -maxdepth 1 -mindepth 1 -type d -name '[0-9]*' \
                             | sed 's|./||' | sort -V | tr '\n' ' ' | xargs)
-            # No SHA range — full rebuild (all workflow / workflow_dispatch).
-            # Leave TARGETS_OUT empty so bake-action falls back to the "default"
-            # group in docker-bake.hcl, which lists all three Docker Hub targets.
-            TARGETS_OUT=""
+            # No SHA range — full rebuild: push all stages for all versions.
+            VERSIONS_BASE_OUT="$VERSIONS_OUT"
+            VERSIONS_SECURE_OUT="$VERSIONS_OUT"
           fi
 
-          echo "tag_suffix=${TAG_SUFFIX}"                   >> "$GITHUB_OUTPUT"
-          echo "latest_php_version=${LATEST_PHP_VERSION}"   >> "$GITHUB_OUTPUT"
-          echo "versions=${VERSIONS_OUT}"                   >> "$GITHUB_OUTPUT"
-          echo "targets=${TARGETS_OUT}"                     >> "$GITHUB_OUTPUT"
+          echo "tag_suffix=${TAG_SUFFIX}"                     >> "$GITHUB_OUTPUT"
+          echo "latest_php_version=${LATEST_PHP_VERSION}"     >> "$GITHUB_OUTPUT"
+          echo "versions=${VERSIONS_OUT}"                     >> "$GITHUB_OUTPUT"
+          echo "versions_base=${VERSIONS_BASE_OUT}"           >> "$GITHUB_OUTPUT"
+          echo "versions_secure=${VERSIONS_SECURE_OUT}"       >> "$GITHUB_OUTPUT"
 
           # If no versions were selected for build, skip platform detection/filtering.
           # The build job is already guarded on versions being non-empty.
@@ -316,10 +309,11 @@ jobs:
           TAG_SUFFIX:          ${{ needs.detect.outputs.tag_suffix }}
           LATEST_PHP_VERSION:  ${{ needs.detect.outputs.latest_php_version }}
           VERSIONS:            ${{ needs.detect.outputs.versions }}
+          VERSIONS_BASE:       ${{ needs.detect.outputs.versions_base }}
+          VERSIONS_SECURE:     ${{ needs.detect.outputs.versions_secure }}
           PLATFORMS:           ${{ needs.detect.outputs.platforms }}
           CACHE_FROM_ENABLED:  ${{ inputs.cache_from_enabled }}
           GHCR_REPO:           ${{ steps.ghcr.outputs.repo }}
         with:
-          files:   docker-bake.hcl
-          push:    true
-          targets: ${{ needs.detect.outputs.targets }}
+          files: docker-bake.hcl
+          push:  true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -27,13 +27,15 @@
 
 # ─── Default group ───────────────────────────────────────────────────────────
 # Running `docker buildx bake` without arguments builds this group.
-# Used by the `all` workflow (full rebuild / workflow_dispatch) when no
-# before/after SHA range is available, and as a fallback for local development.
-# Note: Docker Buildx bake only pushes explicitly listed targets; context
-# dependencies (downloader, php-php-ext, php-secure-int) are built and pushed
-# to GHCR as part of the dependency chain but are NOT pushed to Docker Hub.
+# php-advance depends on php-secure depends on php-base, so requesting
+# php-advance causes the full chain to be built for every version in VERSIONS.
+# VERSIONS_BASE / VERSIONS_SECURE control which of those versions are tagged
+# and pushed to Docker Hub for the base / secure stages respectively; advance
+# is always pushed for every version in VERSIONS (since advance cascades from
+# all upstream changes).  No target names are passed as CLI arguments, which
+# avoids the bake v0.31+ restriction on resolving matrix-generated names.
 group "default" {
-  targets = ["php-base", "php-secure", "php-advance"]
+  targets = ["php-advance"]
 }
 
 variable "REPO"                          { default = "devpanel/php"            }
@@ -41,7 +43,13 @@ variable "REPO"                          { default = "devpanel/php"            }
 # The default below is a convenience fallback for local development only.
 variable "GHCR_REPO"                     { default = "ghcr.io/devpanel/php"    }
 variable "TAG_SUFFIX"                    { default = ""                        }
-variable "VERSIONS"                      { default = "7.4 8.0 8.1 8.2 8.3"     }
+variable "VERSIONS"                      { default = "7.4 8.0 8.1 8.2 8.3"    }
+# VERSIONS_BASE / VERSIONS_SECURE: subsets of VERSIONS for which the base /
+# secure final images should be tagged and pushed to Docker Hub.  Both default
+# to the full VERSIONS set so a plain `docker buildx bake` pushes everything.
+# CI narrows these to only the versions whose files actually changed.
+variable "VERSIONS_BASE"                 { default = "7.4 8.0 8.1 8.2 8.3"    }
+variable "VERSIONS_SECURE"               { default = "7.4 8.0 8.1 8.2 8.3"    }
 variable "LATEST_PHP_VERSION"            { default = "8.3"                     }
 variable "CODESERVER_VERSION"            { default = ""                        }
 variable "CORERULESET_VERSION"           { default = "3.3.5"                   }
@@ -63,6 +71,15 @@ variable "VERSIONS_NEEDING_MULTIPART_FIX" { default = "7.4 8.0" }
 function "ver_key" {
   params = [v]
   result = replace(v, ".", "_")
+}
+
+# should_push: true if version v is listed in the space-separated stage_versions
+# string.  Used to make Docker Hub tags conditional: targets whose version is not
+# in the per-stage list are still built (for the dependency chain / GHCR cache)
+# but are not tagged and therefore not pushed to Docker Hub.
+function "should_push" {
+  params = [stage_versions, v]
+  result = contains(split(" ", trimspace(stage_versions)), v)
 }
 
 function "cache_from" {
@@ -167,7 +184,7 @@ target "php-base" {
     common-downloader = "target:downloader"
     common            = "./base"
   }
-  tags       = ["${REPO}:${version}-base${TAG_SUFFIX}"]
+  tags       = should_push(VERSIONS_BASE, version) ? ["${REPO}:${version}-base${TAG_SUFFIX}"] : []
   cache-from = cache_from("php${ver_key(version)}-base")
   cache-to   = cache_to("php${ver_key(version)}-base")
 }
@@ -219,7 +236,7 @@ target "php-secure" {
   dockerfile = "Dockerfile"
   context    = contains(split(" ", VERSIONS_NEEDING_MULTIPART_FIX), version) ? "${version}/secure" : "secure"
   contexts   = { secure-intermediate = "target:php${ver_key(version)}-secure-int" }
-  tags       = ["${REPO}:${version}-secure${TAG_SUFFIX}"]
+  tags       = should_push(VERSIONS_SECURE, version) ? ["${REPO}:${version}-secure${TAG_SUFFIX}"] : []
   cache-from = cache_from("php${ver_key(version)}-secure")
   cache-to   = cache_to("php${ver_key(version)}-secure")
 }


### PR DESCRIPTION
This pull request refactors the PHP images build workflow to more efficiently and accurately determine which image stages (base, secure, advance) and versions need to be built and pushed, especially in response to selective changes. The main improvements are in how per-version, per-stage builds are tracked and how Docker Hub tagging/pushing is controlled, resulting in more targeted builds and less unnecessary work.

**Workflow logic improvements:**

* The detection script in `.github/workflows/build-php-images.yml` now computes separate lists for which PHP versions require the `base`, `secure`, and `advance` stages to be rebuilt, rather than a single list and a flat set of targets. This enables fine-grained control over which images are tagged and pushed.
* The outputs from the detect job are updated to provide `versions_base` and `versions_secure` (alongside `versions`), and these are passed through the workflow for use in subsequent jobs. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L48-R49) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R312-L325)

**Docker build configuration changes:**

* The `docker-bake.hcl` file now accepts `VERSIONS_BASE` and `VERSIONS_SECURE` variables, defaulting to all versions but narrowed by CI to only those needing a rebuild.
* A new `should_push` function is introduced in `docker-bake.hcl` to conditionally tag and push only the relevant base/secure images for Docker Hub, while still building all dependencies for cache and GHCR.
* The `php-base` and `php-secure` targets now use `should_push` to determine if they should be tagged for Docker Hub, avoiding unnecessary pushes for unchanged versions. [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L170-R187) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L222-R239)
* The default build group in `docker-bake.hcl` is simplified to only include the `php-advance` target, since that always cascades from all upstream changes, and the tagging logic now relies on the new variables.

These changes make the build process more efficient and precise, reducing unnecessary builds and Docker Hub pushes while maintaining full dependency and cache integrity.

**References:**
- Workflow logic: [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L102-R166) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L48-R49) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R312-L325)
- Docker build configuration: [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R47-R52) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R76-R84) [[3]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L170-R187) [[4]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L222-R239) [[5]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L30-R38)