### PR TITLE
Restore local checkout context in bake-action configuration

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -315,5 +315,6 @@ jobs:
           CACHE_FROM_ENABLED:  ${{ inputs.cache_from_enabled }}
           GHCR_REPO:           ${{ steps.ghcr.outputs.repo }}
         with:
+          source: .
           files: docker-bake.hcl
           push:  true


### PR DESCRIPTION
This pull request introduces a minor update to the build workflow configuration. The change specifies the build context for Docker image creation, ensuring that the source directory is set correctly.

* Workflow configuration update:
  * [`.github/workflows/build-php-images.yml`](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R318): Added the `source: .` parameter to the Docker build step to explicitly set the build context to the current directory.