### PR TITLE
Enhance last successful SHA computation with workflow_dispatch runs

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -30,28 +30,49 @@ jobs:
           # run on this branch as the effective before_sha.  This covers every
           # commit since the last known-good build, regardless of how many
           # prior runs were cancelled in the interim.
-          LAST_SUCCESS_SHA=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/docker-build-on-push.yml/runs?branch=${{ github.ref_name }}&status=success&per_page=1" \
-            --jq '.workflow_runs[0].head_sha // ""')
+          #
+          # We query every workflow that calls the shared reusable build
+          # workflow (on-push and workflow_dispatch/all) so that a successful
+          # full-rebuild dispatch is not ignored when computing the diff range.
+          # Fetch the last 10 from each so we have enough candidates to find
+          # the closest reachable ancestor even when recent runs share SHAs.
+          CANDIDATES=$({
+            gh api \
+              "repos/${{ github.repository }}/actions/workflows/docker-build-on-push.yml/runs?branch=${{ github.ref_name }}&status=success&per_page=10" \
+              --jq '.workflow_runs[].head_sha // empty'
+            gh api \
+              "repos/${{ github.repository }}/actions/workflows/docker-build-all.yml/runs?branch=${{ github.ref_name }}&status=success&per_page=10" \
+              --jq '.workflow_runs[].head_sha // empty'
+          } | grep . | sort -u)
+
+          # Among all candidates, pick the closest reachable ancestor of the
+          # current commit — the one with the smallest ahead_by distance.
+          # This is more correct than using timestamps because it is based on
+          # the actual git ancestry of the branch rather than wall-clock time.
+          LAST_SUCCESS_SHA=""
+          BEST_AHEAD=""
+          while IFS= read -r SHA; do
+            [[ -z "$SHA" || "$SHA" == "${{ github.sha }}" ]] && continue
+            COMPARE=$(gh api \
+              "repos/${{ github.repository }}/compare/${SHA}...${{ github.sha }}" \
+              --jq '{status: .status, ahead_by: .ahead_by}' 2>/dev/null || true)
+            STATUS=$(printf '%s' "$COMPARE" | jq -r '.status // ""')
+            AHEAD=$(printf '%s' "$COMPARE" | jq -r '.ahead_by // empty')
+            if [[ "$STATUS" == "ahead" || "$STATUS" == "identical" ]] && [[ "$AHEAD" =~ ^[0-9]+$ ]]; then
+              if [[ -z "$BEST_AHEAD" || "$AHEAD" -lt "$BEST_AHEAD" ]]; then
+                BEST_AHEAD="$AHEAD"
+                LAST_SUCCESS_SHA="$SHA"
+              fi
+            fi
+          done <<< "$CANDIDATES"
 
           BEFORE_SHA=""
-          if [[ -n "$LAST_SUCCESS_SHA" && "$LAST_SUCCESS_SHA" != "${{ github.sha }}" ]]; then
-            # Validate that LAST_SUCCESS_SHA is still reachable from the current
-            # commit — it may not be after a force-push or history rewrite.
-            # The GitHub compare API returns "ahead" when github.sha is a
-            # descendant of LAST_SUCCESS_SHA (the normal case).
-            COMPARE_STATUS=$(gh api \
-              "repos/${{ github.repository }}/compare/${LAST_SUCCESS_SHA}...${{ github.sha }}" \
-              --jq '.status // ""' 2>/dev/null || true)
-            if [[ "$COMPARE_STATUS" == "ahead" || "$COMPARE_STATUS" == "identical" ]]; then
-              BEFORE_SHA="$LAST_SUCCESS_SHA"
-            fi
-          fi
-
-          if [[ -z "$BEFORE_SHA" ]]; then
-            # Either no prior successful run, the last-success SHA equals the
-            # current commit, or it is no longer reachable (e.g. after a
-            # force-push).  Fall back to the push event's own before SHA.
+          if [[ -n "$LAST_SUCCESS_SHA" ]]; then
+            BEFORE_SHA="$LAST_SUCCESS_SHA"
+          else
+            # No prior successful run found whose commit is reachable from the
+            # current commit (e.g. first run ever, or after a force-push).
+            # Fall back to the push event's own before SHA.
             BEFORE_SHA="${{ github.event.before }}"
           fi
 


### PR DESCRIPTION
This pull request updates the logic in the `.github/workflows/docker-build-on-push.yml` workflow to more accurately determine the correct commit range for Docker builds. The new approach considers successful runs from both the push and full-rebuild workflows, and selects the closest reachable ancestor based on Git ancestry rather than relying solely on timestamps or the most recent successful run.

Improvements to Docker build commit range detection:

* The workflow now queries the last 10 successful runs from both the `docker-build-on-push.yml` and `docker-build-all.yml` workflows to gather candidate SHAs, ensuring that successful full-rebuilds are considered when determining the diff range.
* Among all candidate SHAs, the workflow selects the closest reachable ancestor of the current commit (i.e., the SHA with the smallest `ahead_by` distance), providing a more accurate and robust determination of the commit range for builds, especially after force-pushes or history rewrites.
* If no suitable prior successful run is found, the workflow falls back to using the push event's `before` SHA, maintaining compatibility with first runs or after significant history changes.