### PR TITLE
Fix HCL syntax errors in docker-bake.hcl

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -122,9 +122,7 @@ function "cache_from_registry" {
 
 function "cache_to_registry" {
   params = [ref, scope]
-  result = GHCR_WRITABLE == "true" \
-    ? concat(["type=registry,ref=${ref},mode=max"], cache_to(scope)) \
-    : concat(["type=registry,ref=${ref},mode=max,ignore-error=true"], cache_to(scope))
+  result = GHCR_WRITABLE == "true" ? concat(["type=registry,ref=${ref},mode=max"], cache_to(scope)) : concat(["type=registry,ref=${ref},mode=max,ignore-error=true"], cache_to(scope))
 }
 
 # ─── Shared downloader (pushed to GHCR, NOT pushed to Docker Hub) ────────────


### PR DESCRIPTION
This pull request makes a minor formatting change to the `cache_to_registry` function in `docker-bake.hcl`. The logic remains the same, but the conditional statement is now written on a single line for improved readability.