### PR TITLE
Enhance GHCR pre-check failure messages with actionable diagnostics

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -263,9 +263,9 @@ jobs:
         run: |
           set -uo pipefail
           REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          ORG=$(echo "${{ github.repository }}" | cut -d'/' -f1)
 
           NOTE="The build will still attempt GHCR cache writes with ignore-error=true; errors will be visible in the bake step log but will not abort the build."
-          PAT_WORKAROUND="To work around organisation-level restrictions, set a GHCR_TOKEN repository secret containing a Personal Access Token with 'write:packages' scope."
 
           # Use a temp netrc file so credentials are not exposed as command-line arguments.
           # umask 0177 ensures the file is created with 0600 from the start (no race window).
@@ -289,6 +289,21 @@ jobs:
             case "${TOKEN_HTTP}" in
               401)
                 REASON="GITHUB_TOKEN was rejected by the GHCR token endpoint (HTTP 401): the token lacks 'packages: write' permission. Verify that the calling workflow job includes 'permissions: packages: write'."
+                echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                echo "writable=false" >> "$GITHUB_OUTPUT"
+                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          ### ❌ GHCR cache write pre-check: failed
+
+          **Diagnosis:** GITHUB_TOKEN was rejected by the GHCR token endpoint (HTTP 401). The token lacks `packages: write` permission.
+
+          **Fix:** Ensure the calling workflow job declares the following permission:
+
+          ```yaml
+          permissions:
+            packages: write
+          ```
+          SUMMARY_EOF
+                echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               403)
                 # Probe read-only access: if a pull token succeeds, the credential is valid
@@ -298,18 +313,66 @@ jobs:
                   "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_LC}:pull" \
                   2>/dev/null || echo "000")
                 if [[ "${PULL_HTTP}" == "200" ]]; then
-                  REASON="GITHUB_TOKEN can read from GHCR (pull token succeeded) but the push token was denied (HTTP 403). This likely indicates the organisation restricts Actions tokens from writing to packages via an organisation-level policy. ${PAT_WORKAROUND}"
+                  REASON="GITHUB_TOKEN can read from GHCR but a push token was denied (HTTP 403). The organisation's Actions token policy likely restricts package writes."
+                  echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                  echo "writable=false" >> "$GITHUB_OUTPUT"
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          ### ❌ GHCR cache write pre-check: failed
+
+          **Diagnosis:** GITHUB_TOKEN can read from GHCR (pull-scoped token succeeded) but a push-scoped token was denied (HTTP 403). This strongly indicates the **organisation's Actions token policy** restricts GITHUB_TOKEN from writing to packages.
+
+          **Option 1 — Organisation owner: allow workflow write permissions**
+          SUMMARY_EOF
+                  cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
+          1. Open <https://github.com/organizations/${ORG}/settings/actions>
+          2. Scroll to **Workflow permissions**
+          3. Select **"Read and write permissions"** and save
+
+          See the GitHub docs: [Setting the permissions of the GITHUB\_TOKEN for your organisation](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)
+
+          **Option 2 — Repository admin: use a Personal Access Token (no org-owner access needed)**
+          SUMMARY_EOF
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `write:packages` scope at <https://github.com/settings/tokens>
+          2. In this repository, go to **Settings → Secrets and variables → Actions**
+          3. Add a new repository secret named **`GHCR_TOKEN`** and paste the PAT as the value
+          4. Re-run the workflow
+          SUMMARY_EOF
+                  echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 else
-                  REASON="GITHUB_TOKEN was denied by the GHCR token endpoint for both push (HTTP 403) and pull (HTTP ${PULL_HTTP}) scopes. The package at ghcr.io/${REPO_LC} may not be accessible to this token. ${PAT_WORKAROUND}"
+                  REASON="GITHUB_TOKEN was denied for both push (HTTP 403) and pull (HTTP ${PULL_HTTP}) scopes. The package ghcr.io/${REPO_LC} may not yet exist, may be private, or the organisation blocks all Actions token access to packages."
+                  echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                  echo "writable=false" >> "$GITHUB_OUTPUT"
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          ### ❌ GHCR cache write pre-check: failed
+
+          **Diagnosis:** GITHUB_TOKEN was denied for both push-scoped (HTTP 403) and pull-scoped tokens. The package may not yet exist, may be private, or the organisation's token policy blocks all access.
+
+          **Steps to investigate:**
+          SUMMARY_EOF
+                  cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
+          1. Check whether the package exists: <https://github.com/orgs/${ORG}/packages>
+          2. If the package does not yet exist, it will be created on first push — but write access must be granted first (see options below).
+          3. Check the organisation's Actions settings: <https://github.com/organizations/${ORG}/settings/actions> → **Workflow permissions**
+
+          See the GitHub docs: [Setting the permissions of the GITHUB\_TOKEN for your organisation](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)
+
+          **To unblock the build — Repository admin: use a Personal Access Token (no org-owner access needed)**
+          1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the \`write:packages\` scope at <https://github.com/settings/tokens>
+          2. In this repository, go to **Settings → Secrets and variables → Actions**
+          3. Add a new repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
+          4. Re-run the workflow
+          SUMMARY_EOF
+                  echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 fi
                 ;;
               *)
                 REASON="Could not obtain a GHCR push token for ghcr.io/${REPO_LC} (token endpoint returned HTTP ${TOKEN_HTTP})."
+                echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                echo "writable=false" >> "$GITHUB_OUTPUT"
+                echo "❌ **GHCR cache write pre-check:** failed — ${REASON} ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
             esac
-            echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
-            echo "writable=false" >> "$GITHUB_OUTPUT"
-            echo "❌ **GHCR cache write pre-check:** failed — ${REASON} ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -330,17 +393,56 @@ jobs:
             case "${HTTP_STATUS}" in
               401)
                 REASON="GITHUB_TOKEN was rejected when initiating a GHCR blob upload (HTTP 401): the token lacks 'packages: write' permission. Verify that the calling workflow job includes 'permissions: packages: write'."
+                echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                echo "writable=false" >> "$GITHUB_OUTPUT"
+                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          ### ❌ GHCR cache write pre-check: failed
+
+          **Diagnosis:** GITHUB_TOKEN was rejected when initiating a GHCR blob upload (HTTP 401). The token lacks `packages: write` permission.
+
+          **Fix:** Ensure the calling workflow job declares the following permission:
+
+          ```yaml
+          permissions:
+            packages: write
+          ```
+          SUMMARY_EOF
+                echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               403)
-                REASON="GITHUB_TOKEN was forbidden from writing to ghcr.io/${REPO_LC} (HTTP 403). The organisation may restrict Actions token write access to packages via an organisation-level policy, or the package's own access settings may block this token. ${PAT_WORKAROUND}"
+                REASON="GITHUB_TOKEN was forbidden from writing to ghcr.io/${REPO_LC} (HTTP 403). The organisation's Actions token policy or the package's own access settings may block this token."
+                echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                echo "writable=false" >> "$GITHUB_OUTPUT"
+                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          ### ❌ GHCR cache write pre-check: failed
+
+          **Diagnosis:** GITHUB_TOKEN obtained a push-scoped token but the blob upload was still denied (HTTP 403). This can be caused by the **organisation's Actions token policy** or **package-level access restrictions**.
+
+          **Option 1 — Organisation owner: check workflow permissions and package access**
+          SUMMARY_EOF
+                cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
+          1. Check workflow permissions: <https://github.com/organizations/${ORG}/settings/actions> → **Workflow permissions** → select **"Read and write permissions"** and save
+          2. If the package already exists, check its access settings: navigate to the package at <https://github.com/orgs/${ORG}/packages>, open its **Settings** tab, and ensure this repository has write access under **Actions access**
+
+          See:
+          - [Setting the permissions of the GITHUB\_TOKEN for your organisation](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)
+          - [Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility)
+
+          **Option 2 — Repository admin: use a Personal Access Token (no org-owner access needed)**
+          1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the \`write:packages\` scope at <https://github.com/settings/tokens>
+          2. In this repository, go to **Settings → Secrets and variables → Actions**
+          3. Add a new repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
+          4. Re-run the workflow
+          SUMMARY_EOF
+                echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               *)
                 REASON="GITHUB_TOKEN does not have write access to ghcr.io/${REPO_LC} (HTTP ${HTTP_STATUS})."
+                echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
+                echo "writable=false" >> "$GITHUB_OUTPUT"
+                echo "❌ **GHCR cache write pre-check:** failed — ${REASON} ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
             esac
-            echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
-            echo "writable=false" >> "$GITHUB_OUTPUT"
-            echo "❌ **GHCR cache write pre-check:** failed — ${REASON} ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Set up QEMU


### PR DESCRIPTION
This pull request enhances the GitHub Actions workflow for building PHP images by improving diagnostics and user guidance when the workflow's token cannot write to the GitHub Container Registry (GHCR). The changes focus on providing clearer failure messages, actionable troubleshooting steps, and detailed instructions for resolving permissions issues related to GHCR cache writes.

The most important changes are:

**Improved Diagnostics and User Guidance:**
* Added detailed, user-friendly diagnostic messages and step-by-step remediation instructions to the workflow summary (`$GITHUB_STEP_SUMMARY`) when GHCR cache write pre-checks fail due to insufficient permissions or organization-level restrictions. These messages now include both organization-level and repository-level solutions, with direct links to relevant GitHub documentation and settings pages. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R292-R306) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L301-R375) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R396-R445)

**Refined Permission Checks:**
* Enhanced the logic for handling various HTTP error responses (401, 403) from the GHCR token endpoint, providing specific diagnoses and tailored advice depending on the nature of the failure (e.g., missing `packages: write` permission, organization policy restrictions, or package access issues). [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R292-R306) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L301-R375) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R396-R445)

**Workflow Variable Improvements:**
* Introduced an `ORG` variable to extract the organization name from the repository, enabling dynamic generation of links and instructions that are specific to the affected organization.

**Removal of Outdated Guidance:**
* Removed the old, less actionable `PAT_WORKAROUND` variable and replaced it with more comprehensive, inline instructions for using a Personal Access Token as an alternative solution. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R266-L268) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L301-R375) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R396-R445)