### PR TITLE
Enhance GHCR pre-check failure messages and upgrade actions/checkout

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history is needed when before_sha/after_sha are provided so
           # that git diff can compare before_sha..after_sha.
@@ -237,7 +237,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request updates the `.github/workflows/build-php-images.yml` workflow to improve the reliability and clarity of the GitHub Container Registry (GHCR) cache write pre-checks. The changes enhance error diagnosis, provide actionable guidance for resolving permission issues, and update the workflow's dependencies.

**Improvements to GHCR cache write diagnostics and guidance:**

* The workflow now adds detailed, user-friendly diagnostic messages and step-by-step remediation instructions to the GitHub Actions summary when GHCR cache write permission checks fail. These messages help users quickly identify whether the problem is due to missing `packages: write` permission, organization-level restrictions, or package-level access controls, and explain how to resolve each scenario. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R292-R306) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L301-R375) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R396-R445)

**Workflow dependency updates:**

* The `actions/checkout` action is updated from version 4 to version 6 for both jobs, ensuring the workflow uses the latest features and security updates. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L54-R54) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L240-R240)

**Internal variable and logic improvements:**

* Introduces an `ORG` variable to dynamically determine the organization name, which is then used in documentation links and diagnostic messages.
* Refines the logic for handling various HTTP error codes (401, 403) in token checks, ensuring that all cases provide clear output and guidance. [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L301-R375) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R396-R445)

These changes make the workflow more robust and much easier to troubleshoot when GHCR cache writes fail due to permission issues.