### PR TITLE
Fix VSIX install failure by repacking Copilot Chat for compatibility

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -139,6 +139,21 @@ exit(1); \
     echo "$COPILOT_CHAT_VSIX_SHA256  /tmp/copilot-chat.vsix" | sha256sum -c -; \
   fi
 
+# Repack the Copilot Chat VSIX to use only standard deflate (method 8) or stored
+# (method 0) compression.  Newer VS Marketplace packages may use Deflate64
+# (method 9) or other methods unsupported by the yauzl library bundled with
+# code-server, causing a fatal "Extract" error at install time.  Repacking with
+# the system zip utility (which only emits methods 0 and 8) ensures the VSIX can
+# be installed by any code-server version.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /tmp/_vsix_repack \
+    && unzip -q /tmp/copilot-chat.vsix -d /tmp/_vsix_repack \
+    && rm /tmp/copilot-chat.vsix \
+    && ( cd /tmp/_vsix_repack && zip -r -9 /tmp/copilot-chat.vsix . ) \
+    && rm -rf /tmp/_vsix_repack
+
 
 # ─── Common PHP extensions stage ──────────────────────────────────────────────
 # Builds the shared intermediate that all per-version Dockerfiles extend.


### PR DESCRIPTION
This pull request addresses compatibility issues with installing the Copilot Chat VSIX extension in the `base/Dockerfile`. The main change ensures that the VSIX package uses only standard compression methods, which are supported by the `yauzl` library in code-server, preventing installation errors with certain package formats.

**VSIX repacking for compatibility:**

* Added a step to unpack and repack the `copilot-chat.vsix` file using standard zip compression methods (deflate or stored) to avoid issues with unsupported compression algorithms (like Deflate64) in code-server. This is done by installing `unzip` and `zip`, extracting the VSIX, and repackaging it, ensuring broader compatibility.