### PR TITLE
Enhance VSIX validation and streamline installation process

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -34,8 +34,8 @@ ARG COPILOT_CHAT_VERSION=$COPILOT_CHAT_PINNED_VERSION
 # The integrity check only runs when the downloaded version equals the pinned version.
 ARG COPILOT_CHAT_VSIX_SHA256=82b1bfa67f91e29682aa44b1e831b32a3ca3415676148351c5da57ca7185df98
 
-# Install unzip and zip early so they are available for VSIX validation during
-# the download step and for repacking in the subsequent step.
+# Install unzip and zip early so they are available for VSIX validation and
+# repacking during the download step.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip zip \
     && rm -rf /var/lib/apt/lists/*
@@ -155,8 +155,8 @@ exit(1); \
   if [ "$COPILOT_CHAT_VERSION" = "$COPILOT_CHAT_PINNED_VERSION" ]; then \
     echo "$COPILOT_CHAT_VSIX_SHA256  /tmp/copilot-chat.vsix" | sha256sum -c -; \
   fi; \
-  unzip -tq /tmp/copilot-chat.vsix >/dev/null \
-    || { echo "Downloaded copilot-chat.vsix is not a valid ZIP/VSIX (check marketplace response)" >&2; \
+  unzip -q /tmp/copilot-chat.vsix -d /tmp/_vsix_repack \
+    || { echo "Failed to extract copilot-chat.vsix — file may be invalid or not a valid ZIP/VSIX (check marketplace response)" >&2; \
          exit 1; }
 
 # Repack the Copilot Chat VSIX to use only standard deflate (method 8) or stored
@@ -167,18 +167,15 @@ exit(1); \
 # be installed by any code-server version.
 # TODO: Remove this repack step once code-server upgrades yauzl (or its bundled
 # VS Code) to a version that supports Deflate64 (method 9) natively.
-# The repack is skipped only if the file does not exist (e.g. when the download
-# step was skipped due to a cache hit on an older layer that predates this code).
-# The original file is kept until the repacked archive is fully written, so that
-# a failure mid-repack does not silently lose the VSIX.
-RUN if [ -f /tmp/copilot-chat.vsix ]; then \
-         mkdir /tmp/_vsix_repack \
-         && unzip -q /tmp/copilot-chat.vsix -d /tmp/_vsix_repack \
-         && ( cd /tmp/_vsix_repack && zip -r -9 /tmp/copilot-chat-repacked.vsix . ) \
+# The files were already unpacked into /tmp/_vsix_repack by the download step
+# above.  The repack is skipped only if that directory does not exist (e.g. a
+# cache hit on a layer predating this code).  The original file is kept until the
+# repacked archive is fully written to avoid silently losing the VSIX on failure.
+RUN if [ -d /tmp/_vsix_repack ]; then \
+         ( cd /tmp/_vsix_repack && zip -r -9 /tmp/copilot-chat-repacked.vsix . ) \
          && mv /tmp/copilot-chat-repacked.vsix /tmp/copilot-chat.vsix \
          && rm -rf /tmp/_vsix_repack; \
        fi
-
 
 # ─── Common PHP extensions stage ──────────────────────────────────────────────
 # Builds the shared intermediate that all per-version Dockerfiles extend.
@@ -340,10 +337,8 @@ RUN echo 'Dpkg::Use-Pty "0";' > /etc/apt/apt.conf.d/01dpkg-no-pty \
     && rm /tmp/code-server.deb \
     && rm -f /etc/apt/apt.conf.d/01dpkg-no-pty
 
-# Pre-stage the GitHub Copilot Chat VSIX so it is available after the USER switch.
-# Installation (below) runs as the app user, placing the extension directly into
-# $CODES_USER_DATA_DIR/extensions so code-server finds it with the existing
-# --user-data-dir startup flag (no --extensions-dir override needed).
+# Pre-stage the GitHub Copilot Chat VSIX (repacked with standard Deflate above)
+# so it is available after the USER switch for code-server to install below.
 COPY --from=common-downloader /tmp/copilot-chat.vsix /tmp/copilot-chat.vsix
 
 # Install Composer 2.x (default 2.3.10; PHP 8.3 overrides to 2.7.7 via self-update)
@@ -371,9 +366,9 @@ WORKDIR ${APP_ROOT}
 RUN touch /home/${USER}/.config/code-server/config.yaml
 
 # Install GitHub Copilot Chat extension (not available in Open VSX marketplace).
-# Installs into $CODES_USER_DATA_DIR/extensions — the same directory code-server
-# uses at runtime with --user-data-dir=$CODES_USER_DATA_DIR, so the extension
-# is found without any extra flags.
+# The VSIX was repacked above to use standard Deflate so code-server's bundled
+# yauzl can extract it.  Installs into $CODES_USER_DATA_DIR/extensions so the
+# extension is found with the existing --user-data-dir=$CODES_USER_DATA_DIR flag.
 RUN mkdir -p $CODES_USER_DATA_DIR/extensions \
     && code-server --extensions-dir $CODES_USER_DATA_DIR/extensions --install-extension /tmp/copilot-chat.vsix \
     && sudo rm /tmp/copilot-chat.vsix


### PR DESCRIPTION
This pull request improves the installation process for the GitHub Copilot Chat VSIX extension in the `base/Dockerfile` by making the build more robust, secure, and compatible with code-server. The changes ensure only valid extension versions are used, handle VSIX repacking earlier to avoid extraction errors, and clarify documentation.

**Improvements to Copilot Chat VSIX installation and validation:**

* Added a strict semver format validation for `COPILOT_CHAT_VERSION` to prevent malformed or empty values from causing invalid download URLs or silent failures.
* Moved the installation of `unzip` and `zip` earlier in the Dockerfile so they are available for VSIX validation and repacking during the download step.
* Changed the VSIX repacking logic to extract and validate the VSIX immediately after download, ensuring extraction errors are caught early and only valid files proceed to installation. The repack step now only runs if extraction succeeded.
* Updated comments and documentation throughout to clarify the reasons for each step, especially around VSIX repacking and the use of the `--user-data-dir` flag for code-server. [[1]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7R28-R42) [[2]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L324-R341) [[3]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L355-R371)

**Refactoring and cleanup:**

* Simplified the VSIX pre-staging and installation steps, removing redundant comments and ensuring the process is consistent and clear. [[1]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L324-R341) [[2]](diffhunk://#diff-b093d34eec92adf6e0cc6e445edb7147ea45d25fb0c98f2f84a60f5aae6f34f7L355-R371)