### PR TITLE
Fix CODESERVER_VERSION detection with GITHUB_TOKEN in bake step

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -463,6 +463,7 @@ jobs:
           CACHE_FROM_ENABLED:  ${{ inputs.cache_from_enabled }}
           GHCR_REPO:           ${{ steps.ghcr.outputs.repo }}
           GHCR_WRITABLE:       ${{ steps.check-ghcr.outputs.writable }}
+          GITHUB_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
         with:
           source: .
           files: docker-bake.hcl


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by adding the `GITHUB_TOKEN` secret to the job environment. This change allows the workflow to authenticate with GitHub when necessary.