### PR TITLE
Fix GHCR login to use GHCR_TOKEN and improve pre-check diagnostics

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -35,6 +35,13 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+      GHCR_TOKEN:
+        description: >
+          Optional classic Personal Access Token with the write:packages scope.
+          When provided, this token is used instead of GITHUB_TOKEN for GHCR
+          login and write-access checks. Required when the organisation's Actions
+          token policy restricts GITHUB_TOKEN from writing to packages.
+        required: false
 
 jobs:
   detect:
@@ -254,16 +261,26 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Check GHCR write access
         id: check-ghcr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          USING_GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' }}
         run: |
           set -uo pipefail
           REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
           ORG=$(echo "${{ github.repository }}" | cut -d'/' -f1)
+
+          # Determine which credential is in use for accurate diagnostics.
+          # GHA expressions produce the string 'true'/'false', not bash booleans,
+          # so a string comparison is required here.
+          if [[ "${USING_GHCR_TOKEN}" == "true" ]]; then
+            AUTH_CRED_NAME="GHCR_TOKEN"
+          else
+            AUTH_CRED_NAME="GITHUB_TOKEN"
+          fi
 
           NOTE="The build will still attempt GHCR cache writes with ignore-error=true; errors will be visible in the bake step log but will not abort the build."
 
@@ -288,14 +305,21 @@ jobs:
           if [[ -z "${REG_TOKEN}" ]]; then
             case "${TOKEN_HTTP}" in
               401)
-                REASON="GITHUB_TOKEN was rejected by the GHCR token endpoint (HTTP 401): the token lacks 'packages: write' permission. Verify that the calling workflow job includes 'permissions: packages: write'."
+                REASON="${AUTH_CRED_NAME} was rejected by the GHCR token endpoint (HTTP 401): the token lacks the required write permissions."
                 echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                 echo "writable=false" >> "$GITHUB_OUTPUT"
-                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+                cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ### ❌ GHCR cache write pre-check: failed
 
-          **Diagnosis:** GITHUB_TOKEN was rejected by the GHCR token endpoint (HTTP 401). The token lacks `packages: write` permission.
+          **Diagnosis:** ${AUTH_CRED_NAME} was rejected by the GHCR token endpoint (HTTP 401). The token lacks the required write permissions.
 
+          SUMMARY_EOF
+                if [[ "${USING_GHCR_TOKEN}" == "true" ]]; then
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          **Fix:** Ensure the `GHCR_TOKEN` secret contains a valid [classic PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `write:packages` scope. Classic PATs are required because [fine-grained tokens do not support GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry). If the token has expired, regenerate it at <https://github.com/settings/tokens> and update the `GHCR_TOKEN` secret.
+          SUMMARY_EOF
+                else
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
           **Fix:** Ensure the calling workflow job declares the following permission:
 
           ```yaml
@@ -303,6 +327,7 @@ jobs:
             packages: write
           ```
           SUMMARY_EOF
+                fi
                 echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               403)
@@ -313,13 +338,13 @@ jobs:
                   "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_LC}:pull" \
                   2>/dev/null || echo "000")
                 if [[ "${PULL_HTTP}" == "200" ]]; then
-                  REASON="GITHUB_TOKEN can read from GHCR but a push token was denied (HTTP 403). The organisation's Actions token policy likely restricts package writes."
+                  REASON="${AUTH_CRED_NAME} can read from GHCR but a push token was denied (HTTP 403). The organisation's Actions token policy likely restricts package writes."
                   echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                   echo "writable=false" >> "$GITHUB_OUTPUT"
-                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+                  cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ### ❌ GHCR cache write pre-check: failed
 
-          **Diagnosis:** GITHUB_TOKEN can read from GHCR (pull-scoped token succeeded) but a push-scoped token was denied (HTTP 403). This strongly indicates the **organisation's Actions token policy** restricts GITHUB_TOKEN from writing to packages.
+          **Diagnosis:** ${AUTH_CRED_NAME} can read from GHCR (pull-scoped token succeeded) but a push-scoped token was denied (HTTP 403). This strongly indicates the **organisation's Actions token policy** restricts ${AUTH_CRED_NAME} from writing to packages.
 
           **Option 1 — Organisation owner: allow workflow write permissions**
           SUMMARY_EOF
@@ -333,20 +358,22 @@ jobs:
           **Option 2 — Repository admin: use a Personal Access Token (no org-owner access needed)**
           SUMMARY_EOF
                   cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          > **Note:** A classic token is required because [fine-grained tokens do not support GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
           1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `write:packages` scope at <https://github.com/settings/tokens>
           2. In this repository, go to **Settings → Secrets and variables → Actions**
-          3. Add a new repository secret named **`GHCR_TOKEN`** and paste the PAT as the value
+          3. Add or update the repository secret named **`GHCR_TOKEN`** and paste the PAT as the value
           4. Re-run the workflow
           SUMMARY_EOF
                   echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 else
-                  REASON="GITHUB_TOKEN was denied for both push (HTTP 403) and pull (HTTP ${PULL_HTTP}) scopes. The package ghcr.io/${REPO_LC} may not yet exist, may be private, or the organisation blocks all Actions token access to packages."
+                  REASON="${AUTH_CRED_NAME} was denied for both push (HTTP 403) and pull (HTTP ${PULL_HTTP}) scopes. The package ghcr.io/${REPO_LC} may not yet exist, may be private, or the organisation blocks all Actions token access to packages."
                   echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                   echo "writable=false" >> "$GITHUB_OUTPUT"
-                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+                  cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ### ❌ GHCR cache write pre-check: failed
 
-          **Diagnosis:** GITHUB_TOKEN was denied for both push-scoped (HTTP 403) and pull-scoped tokens. The package may not yet exist, may be private, or the organisation's token policy blocks all access.
+          **Diagnosis:** ${AUTH_CRED_NAME} was denied for both push-scoped (HTTP 403) and pull-scoped tokens. The package may not yet exist, may be private, or the organisation's token policy blocks all access.
 
           **Steps to investigate:**
           SUMMARY_EOF
@@ -358,9 +385,12 @@ jobs:
           See the GitHub docs: [Setting the permissions of the GITHUB\_TOKEN for your organisation](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)
 
           **To unblock the build — Repository admin: use a Personal Access Token (no org-owner access needed)**
+
+          > **Note:** A classic token is required because [fine-grained tokens do not support GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
           1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the \`write:packages\` scope at <https://github.com/settings/tokens>
           2. In this repository, go to **Settings → Secrets and variables → Actions**
-          3. Add a new repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
+          3. Add or update the repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
           4. Re-run the workflow
           SUMMARY_EOF
                   echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
@@ -392,14 +422,21 @@ jobs:
           else
             case "${HTTP_STATUS}" in
               401)
-                REASON="GITHUB_TOKEN was rejected when initiating a GHCR blob upload (HTTP 401): the token lacks 'packages: write' permission. Verify that the calling workflow job includes 'permissions: packages: write'."
+                REASON="${AUTH_CRED_NAME} was rejected when initiating a GHCR blob upload (HTTP 401): the token lacks the required write permissions."
                 echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                 echo "writable=false" >> "$GITHUB_OUTPUT"
-                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+                cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ### ❌ GHCR cache write pre-check: failed
 
-          **Diagnosis:** GITHUB_TOKEN was rejected when initiating a GHCR blob upload (HTTP 401). The token lacks `packages: write` permission.
+          **Diagnosis:** ${AUTH_CRED_NAME} was rejected when initiating a GHCR blob upload (HTTP 401). The token lacks the required write permissions.
 
+          SUMMARY_EOF
+                if [[ "${USING_GHCR_TOKEN}" == "true" ]]; then
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+          **Fix:** Ensure the `GHCR_TOKEN` secret contains a valid [classic PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `write:packages` scope. Classic PATs are required because [fine-grained tokens do not support GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry). If the token has expired, regenerate it at <https://github.com/settings/tokens> and update the `GHCR_TOKEN` secret.
+          SUMMARY_EOF
+                else
+                  cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
           **Fix:** Ensure the calling workflow job declares the following permission:
 
           ```yaml
@@ -407,16 +444,17 @@ jobs:
             packages: write
           ```
           SUMMARY_EOF
+                fi
                 echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               403)
-                REASON="GITHUB_TOKEN was forbidden from writing to ghcr.io/${REPO_LC} (HTTP 403). The organisation's Actions token policy or the package's own access settings may block this token."
+                REASON="${AUTH_CRED_NAME} was forbidden from writing to ghcr.io/${REPO_LC} (HTTP 403). The organisation's Actions token policy or the package's own access settings may block this token."
                 echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                 echo "writable=false" >> "$GITHUB_OUTPUT"
-                cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY_EOF'
+                cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ### ❌ GHCR cache write pre-check: failed
 
-          **Diagnosis:** GITHUB_TOKEN obtained a push-scoped token but the blob upload was still denied (HTTP 403). This can be caused by the **organisation's Actions token policy** or **package-level access restrictions**.
+          **Diagnosis:** ${AUTH_CRED_NAME} obtained a push-scoped token but the blob upload was still denied (HTTP 403). This can be caused by the **organisation's Actions token policy** or **package-level access restrictions**.
 
           **Option 1 — Organisation owner: check workflow permissions and package access**
           SUMMARY_EOF
@@ -429,15 +467,18 @@ jobs:
           - [Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility)
 
           **Option 2 — Repository admin: use a Personal Access Token (no org-owner access needed)**
+
+          > **Note:** A classic token is required because [fine-grained tokens do not support GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
           1. Create a [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the \`write:packages\` scope at <https://github.com/settings/tokens>
           2. In this repository, go to **Settings → Secrets and variables → Actions**
-          3. Add a new repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
+          3. Add or update the repository secret named **\`GHCR_TOKEN\`** and paste the PAT as the value
           4. Re-run the workflow
           SUMMARY_EOF
                 echo "> ℹ️ ${NOTE}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               *)
-                REASON="GITHUB_TOKEN does not have write access to ghcr.io/${REPO_LC} (HTTP ${HTTP_STATUS})."
+                REASON="${AUTH_CRED_NAME} does not have write access to ghcr.io/${REPO_LC} (HTTP ${HTTP_STATUS})."
                 echo "::warning title=GHCR cache write likely to fail::${REASON} ${NOTE}"
                 echo "writable=false" >> "$GITHUB_OUTPUT"
                 echo "❌ **GHCR cache write pre-check:** failed — ${REASON} ${NOTE}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This pull request enhances the `build-php-images` GitHub Actions workflow to support using a custom Personal Access Token (PAT) for GitHub Container Registry (GHCR) authentication and write-access checks, in addition to the default `GITHUB_TOKEN`. It improves diagnostics and guidance when permission issues occur, especially in organizations with restricted Actions token policies.

**Authentication and diagnostics improvements:**

* Added support for an optional `GHCR_TOKEN` secret (a classic PAT with `write:packages` scope) to be used for GHCR authentication and write-access checks when organizational policies restrict the default `GITHUB_TOKEN`. The workflow now prefers `GHCR_TOKEN` if provided. (`.github/workflows/build-php-images.yml`) [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R38-R44) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L257-R284)
* Enhanced diagnostic messages and step summaries to dynamically reference the credential in use (`GHCR_TOKEN` or `GITHUB_TOKEN`), providing clearer troubleshooting instructions and distinguishing between token types. (`.github/workflows/build-php-images.yml`) [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L291-R330) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L316-R347) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R361-R376) [[4]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R388-R393) [[5]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58L395-R457) [[6]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R470-R481)

**Guidance and documentation:**

* Updated step summaries and guidance to clarify that a classic PAT is required (since fine-grained tokens do not support GitHub Packages), and provided direct links and instructions for generating and configuring the `GHCR_TOKEN` secret. (`.github/workflows/build-php-images.yml`) [[1]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R361-R376) [[2]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R388-R393) [[3]](diffhunk://#diff-560db35341d2aee06c819e30a018ed60d2ad58c5efab4db5ded23e7fa0d3fd58R470-R481)

These changes make the workflow more robust and user-friendly in environments with strict token policies, reducing friction when pushing to GHCR.