### PR TITLE
Add SSL verification option for Drush commands with MariaDB

### DIFF
--- a/base/config/drush.yml
+++ b/base/config/drush.yml
@@ -1,5 +1,7 @@
 command:
   sql:
+    options:
+      extra: "--skip-ssl-verify-server-cert"
     dump:
       options:
         extra-dump: "--no-tablespaces"


### PR DESCRIPTION
This pull request introduces a configuration update to the Drush SQL command options. The main change is the addition of a flag to skip SSL server certificate verification when running SQL commands.

Configuration updates:

* Added the `--skip-ssl-verify-server-cert` option to the `sql` command in the Drush configuration (`base/config/drush.yml`).