### PR TITLE
Fix workflow commit assignment and fallback logic

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -66,17 +66,7 @@ jobs:
             fi
           done <<< "$CANDIDATES"
 
-          BEFORE_SHA=""
-          if [[ -n "$LAST_SUCCESS_SHA" ]]; then
-            BEFORE_SHA="$LAST_SUCCESS_SHA"
-          else
-            # No prior successful run found whose commit is reachable from the
-            # current commit (e.g. first run ever, or after a force-push).
-            # Fall back to the push event's own before SHA.
-            BEFORE_SHA="${{ github.event.before }}"
-          fi
-
-          echo "before_sha=$BEFORE_SHA" >> "$GITHUB_OUTPUT"
+          echo "before_sha=$LAST_SUCCESS_SHA" >> "$GITHUB_OUTPUT"
 
   build:
     needs: prepare


### PR DESCRIPTION
This pull request simplifies the logic for determining the `before_sha` value in the `docker-build-on-push.yml` workflow. Instead of using a fallback to the push event's `before` SHA when no previous successful run is found, it now always sets `before_sha` to the value of `LAST_SUCCESS_SHA`.

Workflow logic simplification:

* [`.github/workflows/docker-build-on-push.yml`](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L69-R69): Updated the script to always use `LAST_SUCCESS_SHA` for `before_sha`, removing the fallback to `${{ github.event.before }}` when no prior successful run is found.