### PR TITLE
feat: Add tag trigger into docker-build-on-push.yml

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - 'v*'
 
 concurrency:
   group: docker-build-${{ github.ref }}


### PR DESCRIPTION
This pull request makes a small update to the Docker build workflow. It now triggers the workflow not only on pushes to the `main` and `develop` branches but also when a tag starting with `v` is pushed.