### PR TITLE
Fix array expansion in pre-push hook to correctly append changed files

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -59,7 +59,7 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
       batch+=("$file")
     done < <(git diff --name-only "$remote_sha" "$local_sha" 2>/dev/null || true)
   fi
-  CHANGED_FILES+=("${batch[@]}")
+  CHANGED_FILES+=("${batch[@]+"${batch[@]}"}")
 done
 
 # Deduplicate.


### PR DESCRIPTION
This pull request contains a minor update to the `.githooks/pre-push` script to improve its handling of arrays when adding changed files. The change ensures that the script does not add empty arrays, which can prevent potential errors during the pre-push hook execution.