### PR TITLE
Fix syntax for needed_pulls calculation in Docker build workflows

### DIFF
--- a/.github/actions/detect-versions/action.yml
+++ b/.github/actions/detect-versions/action.yml
@@ -96,6 +96,14 @@ outputs:
       pre-seed action may need one authenticated pull per version when the
       codenames cache is cold.
     value: ${{ steps.detect.outputs.all_versions_count }}
+  needed_pulls:
+    description: >
+      Worst-case total number of Docker Hub pulls needed: the sum of
+      build_matrix_length (one pull per build job for the base PHP image)
+      and all_versions_count (one pull per PHP version for the pre-seed
+      codename probe when the cache is cold).  Pass directly to the
+      needed_pulls input of wait-pull-quota.
+    value: ${{ steps.detect.outputs.needed_pulls }}
   tag_suffix:
     description: >
       Docker image tag suffix derived from the branch/ref name.  Empty string
@@ -429,6 +437,7 @@ runs:
           echo "merge_matrix=[]"                    >> "$GITHUB_OUTPUT"
           echo "build_matrix=[]"                    >> "$GITHUB_OUTPUT"
           echo "build_matrix_length=0"              >> "$GITHUB_OUTPUT"
+          echo "needed_pulls=${#_all_vers_arr[@]}"  >> "$GITHUB_OUTPUT"
         else
           echo "total_platforms=${TOTAL_PLATFORMS}" >> "$GITHUB_OUTPUT"
 
@@ -476,6 +485,7 @@ runs:
           echo "build_matrix=${BUILD_MATRIX}" >> "$GITHUB_OUTPUT"
           BUILD_MATRIX_LENGTH="$(printf '%s' "${BUILD_MATRIX}" | jq 'length')"
           echo "build_matrix_length=${BUILD_MATRIX_LENGTH}" >> "$GITHUB_OUTPUT"
+          echo "needed_pulls=$(( BUILD_MATRIX_LENGTH + ${#_all_vers_arr[@]} ))" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Compute tag suffix

--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -78,11 +78,18 @@ jobs:
       # non-fatal; the GHCR layer cache can miss after a base-image update
       # or Dockerfile change).  Waiting once here prevents N matrix jobs
       # from racing each other to use the same pool of available pulls.
+      - name: Compute needed pulls
+        id: quota
+        if: steps.detect.outputs.versions != ''
+        shell: bash
+        run: |
+          echo "needed_pulls=$(( ${{ steps.detect.outputs.build_matrix_length }} + ${{ steps.detect.outputs.all_versions_count }} ))" >> "$GITHUB_OUTPUT"
+
       - name: Wait for Docker Hub pull quota
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) }} + ${{ fromJSON(steps.detect.outputs.all_versions_count) }}
+          needed_pulls: ${{ steps.quota.outputs.needed_pulls }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}

--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -78,18 +78,11 @@ jobs:
       # non-fatal; the GHCR layer cache can miss after a base-image update
       # or Dockerfile change).  Waiting once here prevents N matrix jobs
       # from racing each other to use the same pool of available pulls.
-      - name: Compute needed pulls
-        id: quota
-        if: steps.detect.outputs.versions != ''
-        shell: bash
-        run: |
-          echo "needed_pulls=$(( ${{ steps.detect.outputs.build_matrix_length }} + ${{ steps.detect.outputs.all_versions_count }} ))" >> "$GITHUB_OUTPUT"
-
       - name: Wait for Docker Hub pull quota
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ steps.quota.outputs.needed_pulls }}
+          needed_pulls: ${{ steps.detect.outputs.needed_pulls }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}

--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -82,7 +82,7 @@ jobs:
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) + fromJSON(steps.detect.outputs.all_versions_count) }}
+          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) }} + ${{ fromJSON(steps.detect.outputs.all_versions_count) }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -118,11 +118,18 @@ jobs:
       # non-fatal; the GHCR layer cache can miss after a base-image update
       # or Dockerfile change).  Waiting once here prevents N matrix jobs
       # from racing each other to use the same pool of available pulls.
+      - name: Compute needed pulls
+        id: quota
+        if: steps.detect.outputs.versions != ''
+        shell: bash
+        run: |
+          echo "needed_pulls=$(( ${{ steps.detect.outputs.build_matrix_length }} + ${{ steps.detect.outputs.all_versions_count }} ))" >> "$GITHUB_OUTPUT"
+
       - name: Wait for Docker Hub pull quota
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) }} + ${{ fromJSON(steps.detect.outputs.all_versions_count) }}
+          needed_pulls: ${{ steps.quota.outputs.needed_pulls }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -122,7 +122,7 @@ jobs:
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) + fromJSON(steps.detect.outputs.all_versions_count) }}
+          needed_pulls: ${{ fromJSON(steps.detect.outputs.build_matrix_length) }} + ${{ fromJSON(steps.detect.outputs.all_versions_count) }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -118,18 +118,11 @@ jobs:
       # non-fatal; the GHCR layer cache can miss after a base-image update
       # or Dockerfile change).  Waiting once here prevents N matrix jobs
       # from racing each other to use the same pool of available pulls.
-      - name: Compute needed pulls
-        id: quota
-        if: steps.detect.outputs.versions != ''
-        shell: bash
-        run: |
-          echo "needed_pulls=$(( ${{ steps.detect.outputs.build_matrix_length }} + ${{ steps.detect.outputs.all_versions_count }} ))" >> "$GITHUB_OUTPUT"
-
       - name: Wait for Docker Hub pull quota
         if: steps.detect.outputs.versions != ''
         uses: ./.github/actions/wait-pull-quota
         with:
-          needed_pulls: ${{ steps.quota.outputs.needed_pulls }}
+          needed_pulls: ${{ steps.detect.outputs.needed_pulls }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           build_matrix_length: ${{ steps.detect.outputs.build_matrix_length }}


### PR DESCRIPTION
This pull request refactors how the total number of required Docker Hub pulls (`needed_pulls`) is calculated and passed between GitHub Actions workflows and composite actions. Instead of recomputing this value in multiple places, the calculation is centralized in the `detect-versions` action, and its output is used directly in downstream jobs. This improves maintainability and reduces duplication.

Key changes by theme:

**Centralizing `needed_pulls` calculation:**

* Added a new output `needed_pulls` to the `detect-versions` composite action, which sums `build_matrix_length` and `all_versions_count`. This value represents the worst-case number of Docker Hub pulls needed and is documented for clarity.
* Updated the action logic to compute and output `needed_pulls` in both the empty and populated build matrix cases, ensuring consistent availability of this value. [[1]](diffhunk://#diff-fa6fe707cb751630c45011721ccb3aa191646dd9a97950e1f4b75e83270fa81cR440) [[2]](diffhunk://#diff-fa6fe707cb751630c45011721ccb3aa191646dd9a97950e1f4b75e83270fa81cR488)

**Simplifying workflow usage:**

* Modified the `docker-build-all.yml` and `docker-build-on-push.yml` workflows to use the new `steps.detect.outputs.needed_pulls` output directly, instead of recalculating it inline with expressions. [[1]](diffhunk://#diff-5c30a21a5aa318ce2fb425d36c599ecfa88c4dffa59316037c99b499f8b1f3b6L85-R85) [[2]](diffhunk://#diff-2e46d7a85ae71bb8ee7f96bdf2ee603e97de96c800a26a3b7c5b29653b746a57L125-R125)