### PR TITLE
Add support for environment variables in custom package installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,3 +404,32 @@ SHA256 on every CI run.
 
 The VSIX is architecture-independent, so only one hash value is needed (unlike
 code-server which ships separate `amd64`/`arm64` packages).
+
+## Custom package installer
+
+You can provide a startup script at `.devpanel/custom_package_installer.sh` inside your application root to run custom setup steps during container startup. The startup process will source this script so any variables you explicitly `export` will become available to the rest of the startup sequence. All output (stdout/stderr) from the script is appended to `/tmp/custom_package_installer.log`.
+
+Recommended (explicit exports):
+
+```bash
+#!/bin/bash
+export FOO=bar
+export BAZ="some value"
+```
+
+Auto-export mode (enable inside your custom script):
+
+If you prefer to write plain assignments without `export`, enable auto-export for the duration of the file using `set -a`/`set +a`:
+
+```bash
+#!/bin/bash
+# Auto-export all assignments in this file
+set -a
+FOO=bar
+BAZ="some value"
+set +a
+```
+
+Security note: The startup process will source arbitrary code from `.devpanel/custom_package_installer.sh` as the container startup user. Verify and audit any scripts you place there. Using `set -a` increases the chance of unintentionally exporting variables; use it with care.
+
+Note: `apache-start.sh` will run `set +a` after sourcing your custom script to ensure the shell's auto-export state is cleared even if your script enabled it.

--- a/README.md
+++ b/README.md
@@ -430,6 +430,6 @@ BAZ="some value"
 set +a
 ```
 
-Security note: The startup process will source arbitrary code from `.devpanel/custom_package_installer.sh` as the container startup user. Verify and audit any scripts you place there. Using `set -a` increases the chance of unintentionally exporting variables; use it with care.
+Security note: In this image, the startup process sources arbitrary code from `.devpanel/custom_package_installer.sh` as `root` (the container startup path invokes `sudo -E /bin/bash /scripts/apache-start.sh`). Verify and audit any scripts you place there, because they run with root privileges during startup. Any variables you explicitly `export` (or implicitly export via `set -a`) may remain available to later startup steps, including commands invoked with `sudo -u ... -E`, so use exports with care.
 
 Note: `apache-start.sh` will run `set +a` after sourcing your custom script to ensure the shell's auto-export state is cleared even if your script enabled it.

--- a/base/scripts/apache-start.sh
+++ b/base/scripts/apache-start.sh
@@ -53,41 +53,54 @@ mkdir -p "$CODES_USER_DATA_DIR/extensions"
 chown "${SUDO_USER:-$USER}:" "$CODES_USER_DATA_DIR" "$CODES_USER_DATA_DIR/extensions"
 
 # Install any custom packages.
-# If a user-provided installer exists, source it so any `export`ed variables
-# become visible to this startup script. Redirect stdout/stderr to the log and
-# protect the parent shell from accidental `exit` calls by rewriting `exit` to
-# `return` while sourcing.
+# If a user-provided installer exists, run it in a separate bash process so
+# any `set -e`/`set -u`/traps cannot terminate this startup script, then
+# import only the exported environment it produced.
 if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
-  # Run the installer in the current shell so exported vars persist, but
-  # capture output and avoid aborting startup on errors or `exit` calls.
-  {
-    _had_expand_aliases=0
-    shopt -q expand_aliases && _had_expand_aliases=1
-    # Save current shell options so the installer cannot permanently alter them
-    # (e.g. `set -e`, `set -u`, `set -o pipefail` would otherwise break startup).
-    _saved_shell_opts=$(set +o 2>/dev/null)
+  _installer_env_file=$(mktemp)
+  _installer_rc_file=$(mktemp)
+  bash -c '
+    _installer_path=$1
+    _env_file=$2
+    _rc_file=$3
+
+    trap '"'"'
+      _rc=$?
+      trap - EXIT
+      printf "%s\n" "$_rc" > "$_rc_file"
+      export -p > "$_env_file"
+      exit 0
+    '"'"' EXIT
+
     set +e +u +o pipefail 2>/dev/null || true
-    # Alias exit to return so `exit N` in the installer stops only the sourced
-    # file and propagates the exit status rather than terminating this script.
     shopt -s expand_aliases
-    alias exit='return'
+    alias exit="return"
     # SC1090/SC1091: intentional dynamic source of a user file
     # shellcheck disable=SC1090,SC1091
-    . "$APP_ROOT/.devpanel/custom_package_installer.sh"
+    . "$_installer_path"
     _installer_rc=$?
     unalias exit 2>/dev/null || true
-    if [ "$_had_expand_aliases" -eq 0 ]; then
-      shopt -u expand_aliases
-    fi
-    # Restore shell options to the state before sourcing the installer.
-    eval "$_saved_shell_opts" 2>/dev/null || true
-    # Ensure any auto-export enabled by the custom script is disabled.
-    # `set +a` is idempotent and safe to run even if not previously enabled.
-    set +a 2>/dev/null || true
-    if [ "$_installer_rc" -ne 0 ]; then
-      printf "custom_package_installer.sh exited with code %s (continuing startup)\n" "$_installer_rc"
-    fi
-  } >> /tmp/custom_package_installer.log 2>&1 || true
+    exit "$_installer_rc"
+  ' bash "$APP_ROOT/.devpanel/custom_package_installer.sh" \
+    "$_installer_env_file" "$_installer_rc_file" \
+    >> /tmp/custom_package_installer.log 2>&1 || true
+
+  if [ -f "$_installer_env_file" ]; then
+    # Import only the environment exported by the child shell.
+    # shellcheck disable=SC1090
+    . "$_installer_env_file"
+  fi
+
+  _installer_rc=0
+  if [ -f "$_installer_rc_file" ]; then
+    _installer_rc=$(cat "$_installer_rc_file")
+  fi
+  if [ "${_installer_rc:-0}" -ne 0 ]; then
+    printf "custom_package_installer.sh exited with code %s (continuing startup)\n" \
+      "$_installer_rc" >> /tmp/custom_package_installer.log
+  fi
+
+  rm -f "$_installer_env_file" "$_installer_rc_file"
 fi
 
 set -m

--- a/base/scripts/apache-start.sh
+++ b/base/scripts/apache-start.sh
@@ -55,21 +55,34 @@ chown "${SUDO_USER:-$USER}:" "$CODES_USER_DATA_DIR" "$CODES_USER_DATA_DIR/extens
 # Install any custom packages.
 # If a user-provided installer exists, source it so any `export`ed variables
 # become visible to this startup script. Redirect stdout/stderr to the log and
-# protect the parent shell from accidental `exit` calls by temporarily
-# shadowing `exit` with a harmless function while sourcing.
+# protect the parent shell from accidental `exit` calls by rewriting `exit` to
+# `return` while sourcing.
 if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
   # Run the installer in the current shell so exported vars persist, but
   # capture output and avoid aborting startup on errors or `exit` calls.
   {
-    # SC2329: `exit` is shadowed to prevent sourced script from exiting the parent
-    # shellcheck disable=SC2329
-    exit() { return; }
+    _had_expand_aliases=0
+    case " $(shopt -p expand_aliases) " in
+      *" -s "*) _had_expand_aliases=1 ;;
+    esac
+    # Save current shell options so the installer cannot permanently alter them
+    # (e.g. `set -e`, `set -u`, `set -o pipefail` would otherwise break startup).
+    _saved_shell_opts=$(set +o 2>/dev/null)
+    set +e +u +o pipefail 2>/dev/null || true
+    # Alias exit to return so `exit N` in the installer stops only the sourced
+    # file and propagates the exit status rather than terminating this script.
+    shopt -s expand_aliases
+    alias exit='return'
     # SC1090/SC1091: intentional dynamic source of a user file
     # shellcheck disable=SC1090,SC1091
     . "$APP_ROOT/.devpanel/custom_package_installer.sh"
     _installer_rc=$?
-    # Restore exit by unsetting the function (this restores the builtin).
-    unset -f exit 2>/dev/null || true
+    unalias exit 2>/dev/null || true
+    if [ "$_had_expand_aliases" -eq 0 ]; then
+      shopt -u expand_aliases
+    fi
+    # Restore shell options to the state before sourcing the installer.
+    eval "$_saved_shell_opts" 2>/dev/null || true
     # Ensure any auto-export enabled by the custom script is disabled.
     # `set +a` is idempotent and safe to run even if not previously enabled.
     set +a 2>/dev/null || true

--- a/base/scripts/apache-start.sh
+++ b/base/scripts/apache-start.sh
@@ -53,7 +53,31 @@ mkdir -p "$CODES_USER_DATA_DIR/extensions"
 chown "${SUDO_USER:-$USER}:" "$CODES_USER_DATA_DIR" "$CODES_USER_DATA_DIR/extensions"
 
 # Install any custom packages.
-[ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ] && /bin/bash "$APP_ROOT/.devpanel/custom_package_installer.sh"  >> /tmp/custom_package_installer.log
+# If a user-provided installer exists, source it so any `export`ed variables
+# become visible to this startup script. Redirect stdout/stderr to the log and
+# protect the parent shell from accidental `exit` calls by temporarily
+# shadowing `exit` with a harmless function while sourcing.
+if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
+  # Run the installer in the current shell so exported vars persist, but
+  # capture output and avoid aborting startup on errors or `exit` calls.
+  {
+    # SC2329: `exit` is shadowed to prevent sourced script from exiting the parent
+    # shellcheck disable=SC2329
+    exit() { return; }
+    # SC1090/SC1091: intentional dynamic source of a user file
+    # shellcheck disable=SC1090,SC1091
+    . "$APP_ROOT/.devpanel/custom_package_installer.sh"
+    _installer_rc=$?
+    # Restore exit by unsetting the function (this restores the builtin).
+    unset -f exit 2>/dev/null || true
+    # Ensure any auto-export enabled by the custom script is disabled.
+    # `set +a` is idempotent and safe to run even if not previously enabled.
+    set +a 2>/dev/null || true
+    if [ "$_installer_rc" -ne 0 ]; then
+      printf "custom_package_installer.sh exited with code %s (continuing startup)\n" "$_installer_rc"
+    fi
+  } >> /tmp/custom_package_installer.log 2>&1 || true
+fi
 
 set -m
 if [[ "$CODES_ENABLE" == "yes" ]]; then

--- a/base/scripts/apache-start.sh
+++ b/base/scripts/apache-start.sh
@@ -59,6 +59,7 @@ chown "${SUDO_USER:-$USER}:" "$CODES_USER_DATA_DIR" "$CODES_USER_DATA_DIR/extens
 if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
   _installer_env_file=$(mktemp)
   _installer_rc_file=$(mktemp)
+  chmod 600 "$_installer_env_file" "$_installer_rc_file"
   bash -c '
     _installer_path=$1
     _env_file=$2
@@ -92,8 +93,8 @@ if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
   fi
 
   _installer_rc=0
-  if [ -f "$_installer_rc_file" ]; then
-    _installer_rc=$(cat "$_installer_rc_file")
+  if [ -s "$_installer_rc_file" ]; then
+    read -r _installer_rc < "$_installer_rc_file" || true
   fi
   if [ "${_installer_rc:-0}" -ne 0 ]; then
     printf "custom_package_installer.sh exited with code %s (continuing startup)\n" \

--- a/base/scripts/apache-start.sh
+++ b/base/scripts/apache-start.sh
@@ -62,9 +62,7 @@ if [ -f "$APP_ROOT/.devpanel/custom_package_installer.sh" ]; then
   # capture output and avoid aborting startup on errors or `exit` calls.
   {
     _had_expand_aliases=0
-    case " $(shopt -p expand_aliases) " in
-      *" -s "*) _had_expand_aliases=1 ;;
-    esac
+    shopt -q expand_aliases && _had_expand_aliases=1
     # Save current shell options so the installer cannot permanently alter them
     # (e.g. `set -e`, `set -u`, `set -o pipefail` would otherwise break startup).
     _saved_shell_opts=$(set +o 2>/dev/null)


### PR DESCRIPTION
This pull request adds support for the custom package installer script to export environment variables for the rest of the startup process. The installer is sourced in a way that preserves exported variables and protects the startup process from accidental exits or errors in the custom script. Documentation is updated to explain usage and security considerations.

**Custom package installer support:**

* Added support for `.devpanel/custom_package_installer.sh` script to set persistent exported environment variables. The sourcing is done safely to prevent accidental termination of the startup process. (`apache-start.sh`, `README.md`) [[1]](diffhunk://#diff-ebb1b58f7bf3e029c664fb5898b5c279754a08c262cb205aec261e93423efc4fL56-R80) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R407-R435)

**Documentation updates:**

* Updated `README.md` to document the new custom installer feature, including usage examples, auto-export mode, and security notes about sourcing arbitrary scripts.